### PR TITLE
Fix validity parsing when comments present

### DIFF
--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -176,6 +176,11 @@ func LoadProfileConfig(filename string, preferPQC bool) (*ProfileConfig, error) 
 			key := strings.TrimSpace(parts[0])
 			value := strings.TrimSpace(parts[1])
 
+			// Strip inline comments (anything after # or ;) if present
+			if commentIdx := strings.IndexAny(value, "#;"); commentIdx != -1 {
+				value = strings.TrimSpace(value[:commentIdx])
+			}
+
 			// Remove quotes if present
 			if (strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"")) ||
 				(strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'")) {

--- a/internal/config/profiles_validity_test.go
+++ b/internal/config/profiles_validity_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestProfileValidityInlineComment(t *testing.T) {
+	cfg := `[Default]
+validity = 30 # days
+`
+	tmpFile, err := os.CreateTemp("", "validity-*.cnf")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.WriteString(cfg); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	tmpFile.Close()
+
+	pc, err := LoadProfileConfig(tmpFile.Name(), false)
+	if err != nil {
+		t.Fatalf("failed to load profile config: %v", err)
+	}
+	profile := pc.GetProfile("Default")
+	if profile == nil {
+		t.Fatalf("expected profile 'Default' not found")
+	}
+	if profile.Validity != 30 {
+		t.Errorf("expected validity 30, got %d", profile.Validity)
+	}
+}


### PR DESCRIPTION
## Summary
- strip inline comments when reading profile config values
- add unit test to cover validity parameter with inline comments

## Testing
- `go test ./...` *(fails: downloading deps forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686981911944832c9ec28685c75163b2