### PR TITLE
fix validity parsing from profile

### DIFF
--- a/cmd/pqc.go
+++ b/cmd/pqc.go
@@ -452,7 +452,11 @@ func loadPQCConfig(cmd *cobra.Command) (*PQCConfig, error) {
 	cfg.HawkID = selectedProfile.KeyID
 	cfg.HawkKey = selectedProfile.Secret
 	cfg.Policy = selectedProfile.PolicyID
-	cfg.Validity = fmt.Sprintf("%d", selectedProfile.Validity)
+	if selectedProfile.ValidityString != "" {
+		cfg.Validity = selectedProfile.ValidityString
+	} else {
+		cfg.Validity = fmt.Sprintf("%d", selectedProfile.Validity)
+	}
 
 	// Override with command-line flags
 	if cmd.Flags().Changed("url") {

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -77,7 +77,8 @@ type Profile struct {
 	P12Pass            string
 	KeySize            int
 	KeyType            string
-	Validity           int
+	Validity           int    // Validity in days for backward compatibility
+	ValidityString     string // Original validity string (e.g., "90d", "3m")
 	OutDir             string
 	NoKeyOut           bool
 	Chain              bool
@@ -208,13 +209,12 @@ func LoadProfileConfig(filename string, preferPQC bool) (*ProfileConfig, error) 
 			case "key-type":
 				currentProfile.KeyType = value
 			case "validity":
+				currentProfile.ValidityString = value
 				if days, err := strconv.Atoi(value); err == nil {
 					currentProfile.Validity = days
-				} else {
-					if validityPeriod, err := parseValidityPeriodSimple(value); err == nil {
-						totalDays := validityPeriod.Years*365 + validityPeriod.Months*30 + validityPeriod.Days
-						currentProfile.Validity = totalDays
-					}
+				} else if validityPeriod, err := parseValidityPeriodSimple(value); err == nil {
+					totalDays := validityPeriod.Years*365 + validityPeriod.Months*30 + validityPeriod.Days
+					currentProfile.Validity = totalDays
 				}
 			case "output-dir":
 				currentProfile.OutDir = value


### PR DESCRIPTION
## Summary
- preserve original `validity` string when reading `zcert.cnf`
- use stored validity string when enrolling or generating PQC config

## Testing
- `go test ./...` *(fails: generator.generateOpenSSLConfig undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68698633550c832c9f72afb26255f00f