### PR TITLE
Add CLI-first TypeScript paper-trading MVP scaffold

### DIFF
--- a/paper-trading-mvp/.env.example
+++ b/paper-trading-mvp/.env.example
@@ -1,2 +1,4 @@
-# MVP uses local JSON only; no API keys required.
+# MVP uses local JSON by default; no keys required unless LLM is enabled.
 NODE_ENV=development
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=

--- a/paper-trading-mvp/.env.example
+++ b/paper-trading-mvp/.env.example
@@ -1,0 +1,2 @@
+# MVP uses local JSON only; no API keys required.
+NODE_ENV=development

--- a/paper-trading-mvp/.gitignore
+++ b/paper-trading-mvp/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 artifacts/*.json
+artifacts/report.md
+artifacts/report.html

--- a/paper-trading-mvp/.gitignore
+++ b/paper-trading-mvp/.gitignore
@@ -1,7 +1,3 @@
 node_modules/
 dist/
-data/scanner_queue.json
-data/research_output.json
-data/top_wallets.json
-data/paper_ledger.json
-data/run_summary.json
+artifacts/*.json

--- a/paper-trading-mvp/.gitignore
+++ b/paper-trading-mvp/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+data/scanner_queue.json
+data/research_output.json
+data/top_wallets.json
+data/paper_ledger.json
+data/run_summary.json

--- a/paper-trading-mvp/README.md
+++ b/paper-trading-mvp/README.md
@@ -107,3 +107,6 @@ npm run lint
 - `artifacts/backtest_train_summary.json`
 - `artifacts/backtest_test_summary.json`
 - `artifacts/guardrail_rejections.json`
+
+- `artifacts/report.md`
+- `artifacts/report.html`

--- a/paper-trading-mvp/README.md
+++ b/paper-trading-mvp/README.md
@@ -1,42 +1,75 @@
 # Paper Trading MVP (Prediction Market Multi-Agent)
 
-A CLI-first TypeScript MVP for **simulated** prediction-market research and paper trading.
+CLI-first TypeScript MVP for **offline simulated** prediction-market research and execution.
 
-## What it does
-- Scans local market data with configurable filters.
-- Produces structured research reports.
-- Ranks wallets from sample fills/trades.
-- Combines signals with strategy consensus logic.
-- Applies capped Kelly sizing + hard risk controls.
-- Simulates exits and records reasons.
-- Writes an auditable trade ledger and summary metrics.
+## Safety boundaries
+- No live trading
+- No private keys
+- No real order placement
 
-## What it does **not** do
-- No real trading.
-- No private keys.
-- No live exchange connectors.
-
-## Quickstart
+## Install
 ```bash
+cd paper-trading-mvp
 npm install
+```
+
+## Run full simulation
+```bash
 npm run dev
 ```
 
-## Key output files
-- `data/scanner_queue.json`
-- `data/research_output.json`
-- `data/top_wallets.json`
-- `data/paper_ledger.json`
-- `data/run_summary.json`
+## Run with flags
+```bash
+npm run dev -- --markets ./data/sample_markets.json --trades ./data/sample_trades.json --bankroll 12000
+npm run dev -- --config ./config.override.json
+```
+
+### Supported CLI flags
+- `--markets <path>` custom markets JSON
+- `--trades <path>` custom trade history JSON
+- `--bankroll <number>` override starting bankroll
+- `--config <path>` JSON config override
+
+## Quality checks
+```bash
+npm run typecheck
+npm test
+npm run lint
+```
+
+## Expected output artifacts
+All generated files go to `/artifacts`:
+- `artifacts/scanner_queue.json`
+- `artifacts/research_output.json`
+- `artifacts/top_wallets.json`
+- `artifacts/paper_ledger.json`
+- `artifacts/run_summary.json`
+
+## Example console output
+```text
+--- Scanner Survivors ---
+(index) id                  edge      price
+0       mkt_us_election...  0.0625    0.54
+
+--- Strategy Candidates ---
+(index) market                 direction rationale
+0       mkt_us_election_2028   yes       Consensus 3/3 with YES bias.
+
+--- Simulated Trades ---
+(index) market                 pnl     roi      exit
+0       mkt_us_election_2028   30.86   0.0926   max_holding_time
+
+--- Metrics ---
+{ scanned_markets: 5, simulated_trades: 3, final_bankroll: 10030.82 }
+Artifacts written to /workspace/zcert/paper-trading-mvp/artifacts
+```
+
+## Error handling
+The CLI fails clearly for:
+- missing input files
+- malformed JSON
+- invalid numeric inputs (including bankroll)
+- empty markets input
 
 ## Config
-Edit `src/config/defaultConfig.ts` to tune scanner, strategy, risk, and exit behavior.
-
-## Pipeline command behavior
-`npm run dev` runs the full pipeline end-to-end and prints:
-- scanned markets
-- selected candidates
-- simulated trades
-- final bankroll
-- win rate
-- drawdown
+Default thresholds live in `src/config/defaultConfig.ts`.

--- a/paper-trading-mvp/README.md
+++ b/paper-trading-mvp/README.md
@@ -1,12 +1,12 @@
 # Paper Trading MVP (Prediction Market Multi-Agent)
 
-CLI-first TypeScript MVP for **offline simulated** prediction-market research and execution.
+CLI-first TypeScript MVP for paper simulation and historical backtesting.
 
 ## Safety boundaries
 - No live trading
 - No private keys
 - No wallet signing
-- No real order placement
+- No order placement
 
 ## Install
 ```bash
@@ -14,53 +14,56 @@ cd paper-trading-mvp
 npm install
 ```
 
-## Run full simulation
+## Modes
+Paper mode (default):
 ```bash
-npm run dev
+npm run dev -- --mode paper
+```
+
+Backtest mode:
+```bash
+npm run dev -- --mode backtest
 ```
 
 ## Market source modes
-Sample/offline mode (default):
 ```bash
-npm run dev -- --source sample
+npm run dev -- --mode paper --source sample
+npm run dev -- --mode paper --source polymarket
 ```
 
-Live read-only Polymarket market data mode:
-```bash
-npm run dev -- --source polymarket
-```
-
-> Warning: polymarket mode is **read-only market data**. This project does **not** place orders, sign wallets, or execute live trades.
+> `--source polymarket` is read-only market data only.
 
 ## Historical trade ingestion modes
-Use sample trade history (default):
 ```bash
-npm run dev -- --trade-source sample
+npm run dev -- --mode paper --trade-source sample
+npm run dev -- --mode paper --trade-source csv --trade-file ./data/sample_trades.csv
+npm run dev -- --mode paper --trade-source json --trade-file ./data/sample_trades.json
 ```
 
-Load local CSV fills:
+Backtest with deterministic fixture-style local data:
 ```bash
-npm run dev -- --trade-source csv --trade-file ./data/sample_trades.csv
+npm run dev -- --mode backtest --source sample --trade-source json --trade-file ./data/sample_trades.json
 ```
 
-Load local JSON fills:
-```bash
-npm run dev -- --trade-source json --trade-file ./data/sample_trades.json
-```
+## CLI flags
+- `--mode <paper|backtest>`
+- `--source <sample|polymarket>`
+- `--markets <path>`
+- `--trade-source <sample|csv|json>`
+- `--trade-file <path>`
+- `--bankroll <number>`
+- `--config <path>`
 
-## Run with flags
-```bash
-npm run dev -- --markets ./data/sample_markets.json --trade-source sample --bankroll 12000
-npm run dev -- --config ./config.override.json
-```
-
-### Supported CLI flags
-- `--markets <path>` custom markets JSON
-- `--bankroll <number>` override starting bankroll
-- `--config <path>` JSON config override
-- `--source <sample|polymarket>` market data source selector
-- `--trade-source <sample|csv|json>` historical trade source selector
-- `--trade-file <path>` required for `csv`/`json` trade source
+## Backtest output
+Backtest writes `artifacts/backtest_summary.json` and prints metrics including:
+- total trades
+- win rate
+- realized PnL
+- ROI
+- max drawdown
+- average holding time
+- profit factor
+- sharpe-like score
 
 ## Quality checks
 ```bash
@@ -69,21 +72,8 @@ npm test
 npm run lint
 ```
 
-## Expected output artifacts
-All generated files go to `/artifacts`:
-- `artifacts/scanner_queue.json`
-- `artifacts/research_output.json`
+## Artifacts
+- `artifacts/run_summary.json`
 - `artifacts/wallet_rankings.json`
 - `artifacts/paper_ledger.json`
-- `artifacts/run_summary.json`
-
-## Error handling
-The CLI fails clearly for:
-- missing input files
-- malformed JSON
-- malformed CSV rows
-- invalid numeric inputs (including bankroll)
-- empty markets input
-
-## Config
-Default thresholds live in `src/config/defaultConfig.ts`.
+- `artifacts/backtest_summary.json`

--- a/paper-trading-mvp/README.md
+++ b/paper-trading-mvp/README.md
@@ -54,6 +54,20 @@ npm run dev -- --mode backtest --source sample --trade-source json --trade-file 
 - `--bankroll <number>`
 - `--config <path>`
 
+
+## Strategy guardrails
+Before simulated execution, strategy decisions are gated by validation checks:
+- minimum liquidity
+- maximum spread
+- minimum edge after spread
+- minimum wallet signal sample size
+- reject near-resolution markets
+- reject stale price data
+- reject trades where slippage removes edge
+
+A simple slippage model estimates impact from trade size vs liquidity, then computes `edgeAfterSlippage`.
+Rejected candidates are written to `artifacts/guardrail_rejections.json`.
+
 ## Backtest output
 Backtest writes `artifacts/backtest_summary.json` and prints metrics including:
 - total trades
@@ -77,3 +91,6 @@ npm run lint
 - `artifacts/wallet_rankings.json`
 - `artifacts/paper_ledger.json`
 - `artifacts/backtest_summary.json`
+- `artifacts/backtest_train_summary.json`
+- `artifacts/backtest_test_summary.json`
+- `artifacts/guardrail_rejections.json`

--- a/paper-trading-mvp/README.md
+++ b/paper-trading-mvp/README.md
@@ -1,0 +1,42 @@
+# Paper Trading MVP (Prediction Market Multi-Agent)
+
+A CLI-first TypeScript MVP for **simulated** prediction-market research and paper trading.
+
+## What it does
+- Scans local market data with configurable filters.
+- Produces structured research reports.
+- Ranks wallets from sample fills/trades.
+- Combines signals with strategy consensus logic.
+- Applies capped Kelly sizing + hard risk controls.
+- Simulates exits and records reasons.
+- Writes an auditable trade ledger and summary metrics.
+
+## What it does **not** do
+- No real trading.
+- No private keys.
+- No live exchange connectors.
+
+## Quickstart
+```bash
+npm install
+npm run dev
+```
+
+## Key output files
+- `data/scanner_queue.json`
+- `data/research_output.json`
+- `data/top_wallets.json`
+- `data/paper_ledger.json`
+- `data/run_summary.json`
+
+## Config
+Edit `src/config/defaultConfig.ts` to tune scanner, strategy, risk, and exit behavior.
+
+## Pipeline command behavior
+`npm run dev` runs the full pipeline end-to-end and prints:
+- scanned markets
+- selected candidates
+- simulated trades
+- final bankroll
+- win rate
+- drawdown

--- a/paper-trading-mvp/README.md
+++ b/paper-trading-mvp/README.md
@@ -46,17 +46,36 @@ npm run dev -- --mode backtest --source sample --trade-source json --trade-file 
 ```
 
 ## CLI flags
-- `--mode <paper|backtest>`
+- `--mode <paper|backtest|import>`
 - `--source <sample|polymarket>`
 - `--markets <path>`
-- `--trade-source <sample|csv|json>`
+- `--trade-source <sample|csv|json|fills>`
 - `--trade-file <path>`
 - `--bankroll <number>`
 - `--config <path>`
 - `--llm <on|off>` (default off)
 - `--strict-data <on|off>` (default off)
+- `--input <path>` (import mode)
+- `--input-type <markets|trades|fills>` (import mode)
+- `--output <path>` (import mode)
 
 
+
+
+## Import mode (real dataset normalization)
+Use import mode to normalize real market/trade files into backtest-ready JSON:
+```bash
+npm run dev -- --mode import --input ./data/raw_real_markets.json --input-type markets --output ./data/real_markets.json
+npm run dev -- --mode import --input ./data/raw_real_trades.json --input-type trades --output ./data/real_trades.json
+```
+
+Each import run writes `artifacts/import_summary.json`.
+
+Reality-check workflow on real data:
+```bash
+npm run dev -- --mode backtest --trade-source json --trade-file ./data/real_trades.json --markets ./data/real_markets.json --llm off --strict-data on
+npm run compare:runs
+```
 
 ## Optional LLM research
 Enable optional LLM enrichment (never required):
@@ -112,6 +131,8 @@ npm run lint
 - `artifacts/backtest_train_summary.json`
 - `artifacts/backtest_test_summary.json`
 - `artifacts/guardrail_rejections.json`
+- `artifacts/import_summary.json`
+- `artifacts/comparison_summary.json`
 
 - `artifacts/report.md`
 - `artifacts/report.html`

--- a/paper-trading-mvp/README.md
+++ b/paper-trading-mvp/README.md
@@ -18,6 +18,20 @@ npm install
 npm run dev
 ```
 
+
+## Market source modes
+Sample/offline mode (default):
+```bash
+npm run dev -- --source sample
+```
+
+Live read-only Polymarket market data mode:
+```bash
+npm run dev -- --source polymarket
+```
+
+> Warning: polymarket mode is **read-only market data**. This project does **not** place orders, sign wallets, or execute live trades.
+
 ## Run with flags
 ```bash
 npm run dev -- --markets ./data/sample_markets.json --trades ./data/sample_trades.json --bankroll 12000
@@ -29,6 +43,7 @@ npm run dev -- --config ./config.override.json
 - `--trades <path>` custom trade history JSON
 - `--bankroll <number>` override starting bankroll
 - `--config <path>` JSON config override
+- `--source <sample|polymarket>` market data source selector
 
 ## Quality checks
 ```bash

--- a/paper-trading-mvp/README.md
+++ b/paper-trading-mvp/README.md
@@ -54,6 +54,7 @@ npm run dev -- --mode backtest --source sample --trade-source json --trade-file 
 - `--bankroll <number>`
 - `--config <path>`
 - `--llm <on|off>` (default off)
+- `--strict-data <on|off>` (default off)
 
 
 
@@ -67,6 +68,10 @@ npm run dev -- --mode paper --llm on
 - LLM cannot bypass scanner, risk sizing, strategy guardrails, or backtest rules.
 - If API key is missing, provider fails, response is malformed, or timeout occurs, the system logs a warning and continues with deterministic research.
 - LLM artifacts are persisted to `artifacts/llm_research.json`.
+
+## Data quality diagnostics
+Runs now produce `artifacts/data_quality_report.json` with warnings/critical issues for duplicates, timestamps, price bounds, liquidity, outlier sizes, and market-trade mismatches.
+Use `--strict-data on` to fail run when critical issues are found.
 
 ## Strategy guardrails
 Before simulated execution, strategy decisions are gated by validation checks:

--- a/paper-trading-mvp/README.md
+++ b/paper-trading-mvp/README.md
@@ -53,7 +53,20 @@ npm run dev -- --mode backtest --source sample --trade-source json --trade-file 
 - `--trade-file <path>`
 - `--bankroll <number>`
 - `--config <path>`
+- `--llm <on|off>` (default off)
 
+
+
+## Optional LLM research
+Enable optional LLM enrichment (never required):
+```bash
+npm run dev -- --mode paper --llm on
+```
+
+- LLM adds at most one extra strategy signal.
+- LLM cannot bypass scanner, risk sizing, strategy guardrails, or backtest rules.
+- If API key is missing, provider fails, response is malformed, or timeout occurs, the system logs a warning and continues with deterministic research.
+- LLM artifacts are persisted to `artifacts/llm_research.json`.
 
 ## Strategy guardrails
 Before simulated execution, strategy decisions are gated by validation checks:

--- a/paper-trading-mvp/README.md
+++ b/paper-trading-mvp/README.md
@@ -5,6 +5,7 @@ CLI-first TypeScript MVP for **offline simulated** prediction-market research an
 ## Safety boundaries
 - No live trading
 - No private keys
+- No wallet signing
 - No real order placement
 
 ## Install
@@ -17,7 +18,6 @@ npm install
 ```bash
 npm run dev
 ```
-
 
 ## Market source modes
 Sample/offline mode (default):
@@ -32,18 +32,35 @@ npm run dev -- --source polymarket
 
 > Warning: polymarket mode is **read-only market data**. This project does **not** place orders, sign wallets, or execute live trades.
 
+## Historical trade ingestion modes
+Use sample trade history (default):
+```bash
+npm run dev -- --trade-source sample
+```
+
+Load local CSV fills:
+```bash
+npm run dev -- --trade-source csv --trade-file ./data/sample_trades.csv
+```
+
+Load local JSON fills:
+```bash
+npm run dev -- --trade-source json --trade-file ./data/sample_trades.json
+```
+
 ## Run with flags
 ```bash
-npm run dev -- --markets ./data/sample_markets.json --trades ./data/sample_trades.json --bankroll 12000
+npm run dev -- --markets ./data/sample_markets.json --trade-source sample --bankroll 12000
 npm run dev -- --config ./config.override.json
 ```
 
 ### Supported CLI flags
 - `--markets <path>` custom markets JSON
-- `--trades <path>` custom trade history JSON
 - `--bankroll <number>` override starting bankroll
 - `--config <path>` JSON config override
 - `--source <sample|polymarket>` market data source selector
+- `--trade-source <sample|csv|json>` historical trade source selector
+- `--trade-file <path>` required for `csv`/`json` trade source
 
 ## Quality checks
 ```bash
@@ -56,33 +73,15 @@ npm run lint
 All generated files go to `/artifacts`:
 - `artifacts/scanner_queue.json`
 - `artifacts/research_output.json`
-- `artifacts/top_wallets.json`
+- `artifacts/wallet_rankings.json`
 - `artifacts/paper_ledger.json`
 - `artifacts/run_summary.json`
-
-## Example console output
-```text
---- Scanner Survivors ---
-(index) id                  edge      price
-0       mkt_us_election...  0.0625    0.54
-
---- Strategy Candidates ---
-(index) market                 direction rationale
-0       mkt_us_election_2028   yes       Consensus 3/3 with YES bias.
-
---- Simulated Trades ---
-(index) market                 pnl     roi      exit
-0       mkt_us_election_2028   30.86   0.0926   max_holding_time
-
---- Metrics ---
-{ scanned_markets: 5, simulated_trades: 3, final_bankroll: 10030.82 }
-Artifacts written to /workspace/zcert/paper-trading-mvp/artifacts
-```
 
 ## Error handling
 The CLI fails clearly for:
 - missing input files
 - malformed JSON
+- malformed CSV rows
 - invalid numeric inputs (including bankroll)
 - empty markets input
 

--- a/paper-trading-mvp/data/raw_real_markets.json
+++ b/paper-trading-mvp/data/raw_real_markets.json
@@ -1,0 +1,10 @@
+[
+  {"id":"pm_2024_us_pres","question":"Will Donald Trump win the 2024 US presidential election?","category":"politics","bestBid":0.51,"bestAsk":0.54,"liquidity":1280000,"volume":25400000,"endDate":"2024-11-06T05:00:00Z","lastPriceUpdatedAt":"2024-11-05T23:00:00Z"},
+  {"id":"pm_2024_house","question":"Will Republicans win the US House in 2024?","category":"politics","bestBid":0.58,"bestAsk":0.61,"liquidity":640000,"volume":11000000,"endDate":"2024-11-06T05:00:00Z","lastPriceUpdatedAt":"2024-11-05T23:10:00Z"},
+  {"id":"pm_2024_senate","question":"Will Republicans win the US Senate in 2024?","category":"politics","bestBid":0.62,"bestAsk":0.65,"liquidity":710000,"volume":12400000,"endDate":"2024-11-06T05:00:00Z","lastPriceUpdatedAt":"2024-11-05T23:15:00Z"},
+  {"id":"pm_btc_100k_2025","question":"Will BTC hit $100k before Jan 1, 2025?","category":"crypto","bestBid":0.47,"bestAsk":0.50,"liquidity":540000,"volume":9800000,"endDate":"2025-01-01T00:00:00Z","lastPriceUpdatedAt":"2024-12-31T20:00:00Z"},
+  {"id":"pm_eth_etf_2024","question":"Will spot ETH ETF be approved by Dec 31, 2024?","category":"crypto","bestBid":0.72,"bestAsk":0.75,"liquidity":450000,"volume":8200000,"endDate":"2024-12-31T23:59:59Z","lastPriceUpdatedAt":"2024-07-22T13:00:00Z"},
+  {"id":"pm_recession_2025","question":"Will the US enter recession in 2025?","category":"macro","bestBid":0.33,"bestAsk":0.36,"liquidity":230000,"volume":2900000,"endDate":"2025-12-31T23:59:59Z","lastPriceUpdatedAt":"2025-12-01T12:00:00Z"},
+  {"id":"pm_cpi_over_3_2025","question":"Will US CPI YoY be over 3% in Dec 2025?","category":"macro","bestBid":0.29,"bestAsk":0.31,"liquidity":180000,"volume":1800000,"endDate":"2025-12-31T23:59:59Z","lastPriceUpdatedAt":"2025-12-15T12:00:00Z"},
+  {"id":"pm_superbowl_2025_chiefs","question":"Will the Chiefs win Super Bowl LIX?","category":"sports","bestBid":0.24,"bestAsk":0.27,"liquidity":310000,"volume":4200000,"endDate":"2025-02-10T04:00:00Z","lastPriceUpdatedAt":"2025-02-09T23:00:00Z"}
+]

--- a/paper-trading-mvp/data/raw_real_trades.json
+++ b/paper-trading-mvp/data/raw_real_trades.json
@@ -1,0 +1,18 @@
+[
+  {"maker":"0x111","market_id":"pm_2024_us_pres","category":"politics","usd_amount":350,"price":0.53,"timestamp":"2024-10-30T10:00:00Z"},
+  {"maker":"0x111","market_id":"pm_2024_us_pres","category":"politics","usd_amount":420,"price":0.54,"timestamp":"2024-11-02T13:00:00Z"},
+  {"maker":"0x222","market_id":"pm_2024_us_pres","category":"politics","usd_amount":275,"price":0.52,"timestamp":"2024-11-04T09:00:00Z"},
+  {"maker":"0x333","market_id":"pm_2024_house","category":"politics","usd_amount":180,"price":0.60,"timestamp":"2024-10-25T15:00:00Z"},
+  {"maker":"0x222","market_id":"pm_2024_house","category":"politics","usd_amount":260,"price":0.61,"timestamp":"2024-11-01T18:00:00Z"},
+  {"maker":"0x444","market_id":"pm_2024_senate","category":"politics","usd_amount":200,"price":0.63,"timestamp":"2024-10-20T17:00:00Z"},
+  {"maker":"0x555","market_id":"pm_2024_senate","category":"politics","usd_amount":310,"price":0.64,"timestamp":"2024-11-03T20:00:00Z"},
+  {"maker":"0x666","market_id":"pm_btc_100k_2025","category":"crypto","usd_amount":140,"price":0.49,"timestamp":"2024-11-15T12:00:00Z"},
+  {"maker":"0x666","market_id":"pm_btc_100k_2025","category":"crypto","usd_amount":220,"price":0.50,"timestamp":"2024-12-20T12:00:00Z"},
+  {"maker":"0x777","market_id":"pm_eth_etf_2024","category":"crypto","usd_amount":260,"price":0.74,"timestamp":"2024-07-15T16:00:00Z"},
+  {"maker":"0x777","market_id":"pm_eth_etf_2024","category":"crypto","usd_amount":290,"price":0.73,"timestamp":"2024-07-21T11:00:00Z"},
+  {"maker":"0x888","market_id":"pm_recession_2025","category":"macro","usd_amount":120,"price":0.35,"timestamp":"2025-03-05T10:00:00Z"},
+  {"maker":"0x999","market_id":"pm_recession_2025","category":"macro","usd_amount":170,"price":0.34,"timestamp":"2025-07-12T14:00:00Z"},
+  {"maker":"0xaaa","market_id":"pm_cpi_over_3_2025","category":"macro","usd_amount":95,"price":0.30,"timestamp":"2025-09-20T12:00:00Z"},
+  {"maker":"0xbbb","market_id":"pm_superbowl_2025_chiefs","category":"sports","usd_amount":180,"price":0.26,"timestamp":"2025-01-30T21:00:00Z"},
+  {"maker":"0xccc","market_id":"pm_superbowl_2025_chiefs","category":"sports","usd_amount":210,"price":0.25,"timestamp":"2025-02-05T20:30:00Z"}
+]

--- a/paper-trading-mvp/data/real_markets.json
+++ b/paper-trading-mvp/data/real_markets.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "pm_2024_us_pres",
+    "question": "Will Donald Trump win the 2024 US presidential election?",
+    "category": "politics",
+    "currentPrice": 0.5,
+    "spread": 0.030000000000000027,
+    "liquidity": 1280000,
+    "volume24h": 25400000,
+    "resolutionAt": "2024-11-06T05:00:00Z"
+  },
+  {
+    "id": "pm_2024_house",
+    "question": "Will Republicans win the US House in 2024?",
+    "category": "politics",
+    "currentPrice": 0.5,
+    "spread": 0.030000000000000027,
+    "liquidity": 640000,
+    "volume24h": 11000000,
+    "resolutionAt": "2024-11-06T05:00:00Z"
+  },
+  {
+    "id": "pm_2024_senate",
+    "question": "Will Republicans win the US Senate in 2024?",
+    "category": "politics",
+    "currentPrice": 0.5,
+    "spread": 0.030000000000000027,
+    "liquidity": 710000,
+    "volume24h": 12400000,
+    "resolutionAt": "2024-11-06T05:00:00Z"
+  },
+  {
+    "id": "pm_btc_100k_2025",
+    "question": "Will BTC hit $100k before Jan 1, 2025?",
+    "category": "crypto",
+    "currentPrice": 0.5,
+    "spread": 0.030000000000000027,
+    "liquidity": 540000,
+    "volume24h": 9800000,
+    "resolutionAt": "2025-01-01T00:00:00Z"
+  },
+  {
+    "id": "pm_eth_etf_2024",
+    "question": "Will spot ETH ETF be approved by Dec 31, 2024?",
+    "category": "crypto",
+    "currentPrice": 0.5,
+    "spread": 0.030000000000000027,
+    "liquidity": 450000,
+    "volume24h": 8200000,
+    "resolutionAt": "2024-12-31T23:59:59Z"
+  },
+  {
+    "id": "pm_recession_2025",
+    "question": "Will the US enter recession in 2025?",
+    "category": "macro",
+    "currentPrice": 0.5,
+    "spread": 0.02999999999999997,
+    "liquidity": 230000,
+    "volume24h": 2900000,
+    "resolutionAt": "2025-12-31T23:59:59Z"
+  },
+  {
+    "id": "pm_cpi_over_3_2025",
+    "question": "Will US CPI YoY be over 3% in Dec 2025?",
+    "category": "macro",
+    "currentPrice": 0.5,
+    "spread": 0.020000000000000018,
+    "liquidity": 180000,
+    "volume24h": 1800000,
+    "resolutionAt": "2025-12-31T23:59:59Z"
+  },
+  {
+    "id": "pm_superbowl_2025_chiefs",
+    "question": "Will the Chiefs win Super Bowl LIX?",
+    "category": "sports",
+    "currentPrice": 0.5,
+    "spread": 0.030000000000000027,
+    "liquidity": 310000,
+    "volume24h": 4200000,
+    "resolutionAt": "2025-02-10T04:00:00Z"
+  }
+]

--- a/paper-trading-mvp/data/real_trades.json
+++ b/paper-trading-mvp/data/real_trades.json
@@ -1,0 +1,130 @@
+[
+  {
+    "wallet": "0x111",
+    "marketId": "pm_2024_us_pres",
+    "category": "politics",
+    "stake": 350,
+    "payout": 660.3773584905659,
+    "timestamp": "2024-10-30T10:00:00Z"
+  },
+  {
+    "wallet": "0x111",
+    "marketId": "pm_2024_us_pres",
+    "category": "politics",
+    "stake": 420,
+    "payout": 777.7777777777777,
+    "timestamp": "2024-11-02T13:00:00Z"
+  },
+  {
+    "wallet": "0x222",
+    "marketId": "pm_2024_us_pres",
+    "category": "politics",
+    "stake": 275,
+    "payout": 528.8461538461538,
+    "timestamp": "2024-11-04T09:00:00Z"
+  },
+  {
+    "wallet": "0x333",
+    "marketId": "pm_2024_house",
+    "category": "politics",
+    "stake": 180,
+    "payout": 300,
+    "timestamp": "2024-10-25T15:00:00Z"
+  },
+  {
+    "wallet": "0x222",
+    "marketId": "pm_2024_house",
+    "category": "politics",
+    "stake": 260,
+    "payout": 426.2295081967213,
+    "timestamp": "2024-11-01T18:00:00Z"
+  },
+  {
+    "wallet": "0x444",
+    "marketId": "pm_2024_senate",
+    "category": "politics",
+    "stake": 200,
+    "payout": 317.46031746031747,
+    "timestamp": "2024-10-20T17:00:00Z"
+  },
+  {
+    "wallet": "0x555",
+    "marketId": "pm_2024_senate",
+    "category": "politics",
+    "stake": 310,
+    "payout": 484.375,
+    "timestamp": "2024-11-03T20:00:00Z"
+  },
+  {
+    "wallet": "0x666",
+    "marketId": "pm_btc_100k_2025",
+    "category": "crypto",
+    "stake": 140,
+    "payout": 285.7142857142857,
+    "timestamp": "2024-11-15T12:00:00Z"
+  },
+  {
+    "wallet": "0x666",
+    "marketId": "pm_btc_100k_2025",
+    "category": "crypto",
+    "stake": 220,
+    "payout": 440,
+    "timestamp": "2024-12-20T12:00:00Z"
+  },
+  {
+    "wallet": "0x777",
+    "marketId": "pm_eth_etf_2024",
+    "category": "crypto",
+    "stake": 260,
+    "payout": 351.35135135135135,
+    "timestamp": "2024-07-15T16:00:00Z"
+  },
+  {
+    "wallet": "0x777",
+    "marketId": "pm_eth_etf_2024",
+    "category": "crypto",
+    "stake": 290,
+    "payout": 397.2602739726027,
+    "timestamp": "2024-07-21T11:00:00Z"
+  },
+  {
+    "wallet": "0x888",
+    "marketId": "pm_recession_2025",
+    "category": "macro",
+    "stake": 120,
+    "payout": 342.8571428571429,
+    "timestamp": "2025-03-05T10:00:00Z"
+  },
+  {
+    "wallet": "0x999",
+    "marketId": "pm_recession_2025",
+    "category": "macro",
+    "stake": 170,
+    "payout": 499.99999999999994,
+    "timestamp": "2025-07-12T14:00:00Z"
+  },
+  {
+    "wallet": "0xaaa",
+    "marketId": "pm_cpi_over_3_2025",
+    "category": "macro",
+    "stake": 95,
+    "payout": 316.6666666666667,
+    "timestamp": "2025-09-20T12:00:00Z"
+  },
+  {
+    "wallet": "0xbbb",
+    "marketId": "pm_superbowl_2025_chiefs",
+    "category": "sports",
+    "stake": 180,
+    "payout": 692.3076923076923,
+    "timestamp": "2025-01-30T21:00:00Z"
+  },
+  {
+    "wallet": "0xccc",
+    "marketId": "pm_superbowl_2025_chiefs",
+    "category": "sports",
+    "stake": 210,
+    "payout": 840,
+    "timestamp": "2025-02-05T20:30:00Z"
+  }
+]

--- a/paper-trading-mvp/data/sample_markets.json
+++ b/paper-trading-mvp/data/sample_markets.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "mkt_us_election_2028",
+    "question": "Will candidate A win the 2028 election?",
+    "category": "politics",
+    "currentPrice": 0.54,
+    "spread": 0.03,
+    "liquidity": 85000,
+    "volume24h": 45000,
+    "resolutionAt": "2028-11-05T00:00:00Z"
+  },
+  {
+    "id": "mkt_btc_120k_2026",
+    "question": "Will BTC hit $120k by year-end 2026?",
+    "category": "crypto",
+    "currentPrice": 0.41,
+    "spread": 0.04,
+    "liquidity": 56000,
+    "volume24h": 39000,
+    "resolutionAt": "2026-12-31T23:59:59Z"
+  },
+  {
+    "id": "mkt_nba_finals_2026",
+    "question": "Will Team X win the 2026 NBA Finals?",
+    "category": "sports",
+    "currentPrice": 0.62,
+    "spread": 0.07,
+    "liquidity": 18000,
+    "volume24h": 12000,
+    "resolutionAt": "2026-06-30T00:00:00Z"
+  },
+  {
+    "id": "mkt_fed_cut_july",
+    "question": "Will the Fed cut rates by July meeting?",
+    "category": "macro",
+    "currentPrice": 0.33,
+    "spread": 0.02,
+    "liquidity": 43000,
+    "volume24h": 27000,
+    "resolutionAt": "2026-07-30T18:00:00Z"
+  },
+  {
+    "id": "mkt_meme_other",
+    "question": "Will meme token XYZ trend on social media next week?",
+    "category": "other",
+    "currentPrice": 0.48,
+    "spread": 0.08,
+    "liquidity": 5000,
+    "volume24h": 2500,
+    "resolutionAt": "2026-05-07T00:00:00Z"
+  }
+]

--- a/paper-trading-mvp/data/sample_trades.csv
+++ b/paper-trading-mvp/data/sample_trades.csv
@@ -1,0 +1,5 @@
+wallet,marketId,category,stake,payout,timestamp
+0xaaa,mkt_us_election_2028,politics,100,160,2026-03-01T10:00:00Z
+0xaaa,mkt_fed_cut_july,macro,120,0,2026-03-11T09:00:00Z
+0xbbb,mkt_btc_120k_2026,crypto,200,0,2026-03-03T10:00:00Z
+0xbbb,mkt_fed_cut_july,macro,220,380,2026-03-08T14:00:00Z

--- a/paper-trading-mvp/data/sample_trades.json
+++ b/paper-trading-mvp/data/sample_trades.json
@@ -1,0 +1,17 @@
+[
+  {"wallet":"0xaaa","marketId":"mkt_us_election_2028","category":"politics","stake":100,"payout":160,"timestamp":"2026-03-01T10:00:00Z"},
+  {"wallet":"0xaaa","marketId":"mkt_fed_cut_july","category":"macro","stake":120,"payout":0,"timestamp":"2026-03-11T09:00:00Z"},
+  {"wallet":"0xaaa","marketId":"mkt_btc_120k_2026","category":"crypto","stake":80,"payout":140,"timestamp":"2026-03-20T11:00:00Z"},
+  {"wallet":"0xaaa","marketId":"mkt_us_election_2028","category":"politics","stake":140,"payout":230,"timestamp":"2026-03-27T13:00:00Z"},
+  {"wallet":"0xbbb","marketId":"mkt_btc_120k_2026","category":"crypto","stake":200,"payout":0,"timestamp":"2026-03-03T10:00:00Z"},
+  {"wallet":"0xbbb","marketId":"mkt_fed_cut_july","category":"macro","stake":220,"payout":380,"timestamp":"2026-03-08T14:00:00Z"},
+  {"wallet":"0xbbb","marketId":"mkt_btc_120k_2026","category":"crypto","stake":180,"payout":300,"timestamp":"2026-03-15T10:30:00Z"},
+  {"wallet":"0xbbb","marketId":"mkt_us_election_2028","category":"politics","stake":120,"payout":0,"timestamp":"2026-03-24T15:40:00Z"},
+  {"wallet":"0xccc","marketId":"mkt_fed_cut_july","category":"macro","stake":90,"payout":150,"timestamp":"2026-03-02T12:00:00Z"},
+  {"wallet":"0xccc","marketId":"mkt_us_election_2028","category":"politics","stake":90,"payout":0,"timestamp":"2026-03-05T12:00:00Z"},
+  {"wallet":"0xccc","marketId":"mkt_btc_120k_2026","category":"crypto","stake":90,"payout":0,"timestamp":"2026-03-16T12:00:00Z"},
+  {"wallet":"0xddd","marketId":"mkt_us_election_2028","category":"politics","stake":150,"payout":280,"timestamp":"2026-03-06T12:00:00Z"},
+  {"wallet":"0xddd","marketId":"mkt_fed_cut_july","category":"macro","stake":160,"payout":280,"timestamp":"2026-03-19T12:00:00Z"},
+  {"wallet":"0xddd","marketId":"mkt_btc_120k_2026","category":"crypto","stake":130,"payout":230,"timestamp":"2026-03-21T12:00:00Z"},
+  {"wallet":"0xddd","marketId":"mkt_us_election_2028","category":"politics","stake":120,"payout":0,"timestamp":"2026-03-29T12:00:00Z"}
+]

--- a/paper-trading-mvp/docs/ARCHITECTURE.md
+++ b/paper-trading-mvp/docs/ARCHITECTURE.md
@@ -5,7 +5,7 @@ This MVP is a CLI-first, file-backed paper-trading workflow inspired by a multi-
 ## Flow
 1. Scanner reads market JSON, applies filtering/scoring, and writes `artifacts/scanner_queue.json`.
 2. Research reads scanner queue and writes `artifacts/research_output.json`.
-3. Wallet Intelligence ranks wallets from trade history and writes `artifacts/top_wallets.json`.
+3. Wallet Intelligence ranks wallets from trade history and writes `artifacts/wallet_rankings.json`.
 4. Strategy combines scanner/research/wallet signals with consensus logic.
 5. Risk/Sizing applies capped Kelly + hard risk limits.
 6. Exit simulates deterministic exits and assigns exit reason.

--- a/paper-trading-mvp/docs/ARCHITECTURE.md
+++ b/paper-trading-mvp/docs/ARCHITECTURE.md
@@ -1,0 +1,21 @@
+# Architecture Overview
+
+This MVP implements a CLI-first, file-backed paper-trading pipeline inspired by a multi-agent prediction market workflow.
+
+## Flow
+1. **Scanner Agent** reads `data/sample_markets.json`, applies filter gates, and writes `data/scanner_queue.json`.
+2. **Research Agent** reads scanner queue and emits structured reports to `data/research_output.json`.
+3. **Wallet Intelligence Agent** ranks wallets from `data/sample_trades.json` and writes `data/top_wallets.json`.
+4. **Strategy Agent** combines scanner + research + wallet signals into consensus decisions.
+5. **Risk/Sizing Agent** applies capped Kelly and hard risk limits.
+6. **Exit Agent** deterministically simulates exits and labels each exit reason.
+7. **Paper Engine** updates bankroll, persists `data/paper_ledger.json`, and computes metrics.
+
+## Persistence
+- JSON-only persistence for auditability and zero external dependencies.
+- Every step creates artifact files to trace decisions.
+
+## Safety Constraints
+- No live keys.
+- No real API order routing.
+- No private key handling.

--- a/paper-trading-mvp/docs/ARCHITECTURE.md
+++ b/paper-trading-mvp/docs/ARCHITECTURE.md
@@ -1,21 +1,18 @@
 # Architecture Overview
 
-This MVP implements a CLI-first, file-backed paper-trading pipeline inspired by a multi-agent prediction market workflow.
+This MVP is a CLI-first, file-backed paper-trading workflow inspired by a multi-agent prediction market system.
 
 ## Flow
-1. **Scanner Agent** reads `data/sample_markets.json`, applies filter gates, and writes `data/scanner_queue.json`.
-2. **Research Agent** reads scanner queue and emits structured reports to `data/research_output.json`.
-3. **Wallet Intelligence Agent** ranks wallets from `data/sample_trades.json` and writes `data/top_wallets.json`.
-4. **Strategy Agent** combines scanner + research + wallet signals into consensus decisions.
-5. **Risk/Sizing Agent** applies capped Kelly and hard risk limits.
-6. **Exit Agent** deterministically simulates exits and labels each exit reason.
-7. **Paper Engine** updates bankroll, persists `data/paper_ledger.json`, and computes metrics.
+1. Scanner reads market JSON, applies filtering/scoring, and writes `artifacts/scanner_queue.json`.
+2. Research reads scanner queue and writes `artifacts/research_output.json`.
+3. Wallet Intelligence ranks wallets from trade history and writes `artifacts/top_wallets.json`.
+4. Strategy combines scanner/research/wallet signals with consensus logic.
+5. Risk/Sizing applies capped Kelly + hard risk limits.
+6. Exit simulates deterministic exits and assigns exit reason.
+7. Paper Engine updates bankroll, writes `artifacts/paper_ledger.json`, and computes metrics.
+8. Entry point writes `artifacts/run_summary.json`.
 
-## Persistence
-- JSON-only persistence for auditability and zero external dependencies.
-- Every step creates artifact files to trace decisions.
-
-## Safety Constraints
-- No live keys.
-- No real API order routing.
-- No private key handling.
+## Input validation and safety
+- Runtime JSON validation for market/trade inputs.
+- Clear error messages for malformed data and invalid numeric inputs.
+- No live trading, private keys, or order routing.

--- a/paper-trading-mvp/docs/TODO.md
+++ b/paper-trading-mvp/docs/TODO.md
@@ -1,11 +1,9 @@
-# TODO (Post-MVP)
+# TODO (Next Phases)
 
-- Replace deterministic scanner probability estimate with pluggable modeling modules.
-- Add real market connectors (Polymarket/subgraph/websocket) behind feature flags.
-- Add robust time-series simulation with intraday candles.
-- Integrate wallet clustering and wallet-follow confidence decay.
-- Add persistent storage (SQLite/Postgres) and migrations.
-- Add backtest mode with date slicing.
-- Add strategy-level attribution and richer risk overlays.
-- Add real execution adapter (still paper in staging) with strict dry-run guardrails.
-- Add alerting/reporting (Slack/Discord/email).
+- Build live Polymarket market-data adapter (read-only first).
+- Add real historical fills ingestion pipeline from exchange exports.
+- Integrate LLM-powered research agent with prompt/version tracking.
+- Build operator dashboard for runs, positions, and risk telemetry.
+- Add live trading mode only behind compliance review and explicit gated approvals.
+- Add deeper backtesting and walk-forward evaluation tools.
+- Add portfolio-level exposure/risk constraints across correlated markets.

--- a/paper-trading-mvp/docs/TODO.md
+++ b/paper-trading-mvp/docs/TODO.md
@@ -1,0 +1,11 @@
+# TODO (Post-MVP)
+
+- Replace deterministic scanner probability estimate with pluggable modeling modules.
+- Add real market connectors (Polymarket/subgraph/websocket) behind feature flags.
+- Add robust time-series simulation with intraday candles.
+- Integrate wallet clustering and wallet-follow confidence decay.
+- Add persistent storage (SQLite/Postgres) and migrations.
+- Add backtest mode with date slicing.
+- Add strategy-level attribution and richer risk overlays.
+- Add real execution adapter (still paper in staging) with strict dry-run guardrails.
+- Add alerting/reporting (Slack/Discord/email).

--- a/paper-trading-mvp/docs/USER_STORIES.md
+++ b/paper-trading-mvp/docs/USER_STORIES.md
@@ -1,0 +1,9 @@
+# User Stories
+
+1. As a user, I can run scanner filters and inspect which markets pass.
+2. As a user, I can produce deterministic research reports from scanner survivors.
+3. As a user, I can rank wallets from sample historical trade data.
+4. As a user, I can simulate strategy trades without risking money.
+5. As a user, I can review a ledger of all simulated trades and exits.
+6. As a user, I can inspect performance metrics (P&L, win rate, drawdown, sharpe-like).
+7. As a user, I can edit thresholds in `src/config/defaultConfig.ts`.

--- a/paper-trading-mvp/package-lock.json
+++ b/paper-trading-mvp/package-lock.json
@@ -1,0 +1,591 @@
+{
+  "name": "paper-trading-mvp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "paper-trading-mvp",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.15.18",
+        "tsx": "^4.19.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/paper-trading-mvp/package.json
+++ b/paper-trading-mvp/package.json
@@ -7,7 +7,10 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/index.ts",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "tsx --test tests/*.test.ts",
+    "lint": "npm run typecheck"
   },
   "keywords": [
     "paper-trading",

--- a/paper-trading-mvp/package.json
+++ b/paper-trading-mvp/package.json
@@ -10,7 +10,8 @@
     "start": "node dist/index.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "tsx --test tests/*.test.ts",
-    "lint": "npm run typecheck"
+    "lint": "npm run typecheck",
+    "compare:runs": "tsx src/analysis/compareRuns.ts"
   },
   "keywords": [
     "paper-trading",

--- a/paper-trading-mvp/package.json
+++ b/paper-trading-mvp/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "paper-trading-mvp",
+  "version": "0.1.0",
+  "private": true,
+  "description": "CLI-first paper-trading MVP for multi-agent prediction-market research",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js"
+  },
+  "keywords": [
+    "paper-trading",
+    "prediction-market",
+    "typescript",
+    "cli"
+  ],
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^22.15.18",
+    "tsx": "^4.19.2",
+    "typescript": "^5.8.3"
+  }
+}

--- a/paper-trading-mvp/src/agents/exit.ts
+++ b/paper-trading-mvp/src/agents/exit.ts
@@ -1,0 +1,35 @@
+import { AppConfig } from '../config/defaultConfig';
+import { ClosedTrade, SimulatedTrade } from '../types/trade';
+
+const deterministicExitPrice = (trade: SimulatedTrade): number => {
+  // Deterministic pseudo-simulation from trade id characters.
+  const charScore = Array.from(trade.id).reduce((sum, c) => sum + c.charCodeAt(0), 0);
+  const drift = ((charScore % 15) - 7) / 100;
+  return Math.max(0.01, Math.min(0.99, trade.entryPrice + drift));
+};
+
+export const simulateExit = (trade: SimulatedTrade, config: AppConfig): ClosedTrade => {
+  const exitPrice = deterministicExitPrice(trade);
+  const pnl = (exitPrice - trade.entryPrice) * trade.quantity * (trade.direction === 'yes' ? 1 : -1);
+  const roi = trade.positionSize === 0 ? 0 : pnl / trade.positionSize;
+
+  const exitReason =
+    roi >= config.exits.targetRoi
+      ? 'target_hit'
+      : roi <= config.exits.stopRoi
+        ? 'stop_loss'
+        : Math.abs(roi) < 0.02
+          ? 'stale_thesis'
+          : roi > 0.15
+            ? 'volume_spike_placeholder'
+            : 'max_holding_time';
+
+  return {
+    ...trade,
+    exitPrice,
+    closedAt: new Date(Date.now() + trade.maxHoldingMinutes * 60_000).toISOString(),
+    pnl,
+    roi,
+    exitReason
+  };
+};

--- a/paper-trading-mvp/src/agents/llmResearch.ts
+++ b/paper-trading-mvp/src/agents/llmResearch.ts
@@ -1,0 +1,112 @@
+import path from 'node:path';
+import { AppConfig } from '../config/defaultConfig';
+import { ScoredMarket } from '../types/market';
+import { LlmResearchReport } from '../types/signal';
+import { writeJson } from '../utils/io';
+
+const validateLlmReports = (input: unknown): LlmResearchReport[] => {
+  if (!Array.isArray(input)) throw new Error('LLM response must be a JSON array.');
+  return input.map((item, idx) => {
+    if (typeof item !== 'object' || item === null) throw new Error(`LLM response item ${idx} must be an object.`);
+    const obj = item as Record<string, unknown>;
+    if (typeof obj.marketId !== 'string') throw new Error(`LLM response item ${idx} missing marketId.`);
+    if (typeof obj.estimatedProbability !== 'number') throw new Error(`LLM response item ${idx} missing estimatedProbability.`);
+    if (typeof obj.confidence !== 'number') throw new Error(`LLM response item ${idx} missing confidence.`);
+    if (typeof obj.reasoningSummary !== 'string') throw new Error(`LLM response item ${idx} missing reasoningSummary.`);
+    if (!Array.isArray(obj.riskFlags)) throw new Error(`LLM response item ${idx} missing riskFlags.`);
+    if (typeof obj.pass !== 'boolean') throw new Error(`LLM response item ${idx} missing pass.`);
+
+    return {
+      marketId: obj.marketId,
+      estimatedProbability: obj.estimatedProbability,
+      confidence: obj.confidence,
+      reasoningSummary: obj.reasoningSummary,
+      riskFlags: obj.riskFlags.map(String),
+      pass: obj.pass
+    };
+  });
+};
+
+const withTimeout = async <T>(promise: Promise<T>, ms: number): Promise<T> => {
+  return await Promise.race([
+    promise,
+    new Promise<T>((_, reject) => setTimeout(() => reject(new Error('LLM request timeout.')), ms))
+  ]);
+};
+
+const extractText = (provider: AppConfig['llm']['provider'], payload: unknown): string => {
+  const obj = payload as Record<string, unknown>;
+  if (provider === 'openai') {
+    const choices = obj.choices as Array<{ message?: { content?: string } }> | undefined;
+    return choices?.[0]?.message?.content ?? '';
+  }
+  if (provider === 'anthropic') {
+    const content = obj.content as Array<{ text?: string }> | undefined;
+    return content?.[0]?.text ?? '';
+  }
+  return '';
+};
+
+export const runLlmResearch = async (
+  markets: ScoredMarket[],
+  config: AppConfig,
+  fetchImpl: typeof fetch = fetch
+): Promise<LlmResearchReport[]> => {
+  const artifactPath = path.resolve(process.cwd(), config.engine.artifactsDir, 'llm_research.json');
+
+  if (!config.llm.enabled || config.llm.provider === 'none') {
+    writeJson(artifactPath, []);
+    return [];
+  }
+
+  const key = config.llm.provider === 'openai' ? process.env.OPENAI_API_KEY : process.env.ANTHROPIC_API_KEY;
+  if (!key) {
+    console.warn('[llm] Missing API key. Falling back to deterministic research.');
+    writeJson(artifactPath, []);
+    return [];
+  }
+
+  const selected = markets.slice(0, config.llm.maxMarketsPerRun);
+  const prompt = `Return ONLY strict JSON array with fields: marketId, estimatedProbability, confidence, reasoningSummary, riskFlags, pass for markets: ${JSON.stringify(selected.map((m) => ({ id: m.id, question: m.question, price: m.currentPrice, edge: m.estimatedEdge })))}.`;
+
+  try {
+    const req =
+      config.llm.provider === 'openai'
+        ? fetchImpl('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${key}`
+            },
+            body: JSON.stringify({ model: config.llm.model, messages: [{ role: 'user', content: prompt }] })
+          })
+        : fetchImpl('https://api.anthropic.com/v1/messages', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-api-key': key,
+              'anthropic-version': '2023-06-01'
+            },
+            body: JSON.stringify({ model: config.llm.model, max_tokens: 1024, messages: [{ role: 'user', content: prompt }] })
+          });
+
+    const response = await withTimeout(req, config.llm.timeoutMs);
+    if (!response.ok) throw new Error(`LLM request failed with status ${response.status}.`);
+
+    const payload = await response.json();
+    const text = extractText(config.llm.provider, payload);
+    const parsed = JSON.parse(text) as unknown;
+    const reports = validateLlmReports(parsed);
+    writeJson(artifactPath, reports);
+    return reports;
+  } catch (error) {
+    console.warn(`[llm] ${String((error as Error).message)} Falling back to deterministic research.`);
+    writeJson(artifactPath, []);
+    return [];
+  }
+};
+
+export const __private__ = {
+  validateLlmReports,
+  extractText
+};

--- a/paper-trading-mvp/src/agents/research.ts
+++ b/paper-trading-mvp/src/agents/research.ts
@@ -1,14 +1,14 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { AppConfig } from '../config/defaultConfig';
 import { ScoredMarket } from '../types/market';
 import { ResearchReport } from '../types/signal';
+import { readJson, writeJson } from '../utils/io';
 
 const confidenceFromEdge = (edge: number): number => Math.max(0.5, Math.min(0.9, 0.5 + edge * 2));
 
 export const runResearch = (config: AppConfig): ResearchReport[] => {
-  const queuePath = path.resolve(process.cwd(), 'data', 'scanner_queue.json');
-  const queued = JSON.parse(fs.readFileSync(queuePath, 'utf-8')) as ScoredMarket[];
+  const queuePath = path.resolve(process.cwd(), config.engine.artifactsDir, 'scanner_queue.json');
+  const queued = readJson(queuePath) as ScoredMarket[];
 
   const reports = queued.map((market) => {
     const confidence = confidenceFromEdge(market.estimatedEdge);
@@ -33,8 +33,8 @@ export const runResearch = (config: AppConfig): ResearchReport[] => {
     };
   });
 
-  const outputPath = path.resolve(process.cwd(), 'data', 'research_output.json');
-  fs.writeFileSync(outputPath, JSON.stringify(reports, null, 2));
+  const outputPath = path.resolve(process.cwd(), config.engine.artifactsDir, 'research_output.json');
+  writeJson(outputPath, reports);
 
   return reports;
 };

--- a/paper-trading-mvp/src/agents/research.ts
+++ b/paper-trading-mvp/src/agents/research.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { AppConfig } from '../config/defaultConfig';
+import { ScoredMarket } from '../types/market';
+import { ResearchReport } from '../types/signal';
+
+const confidenceFromEdge = (edge: number): number => Math.max(0.5, Math.min(0.9, 0.5 + edge * 2));
+
+export const runResearch = (config: AppConfig): ResearchReport[] => {
+  const queuePath = path.resolve(process.cwd(), 'data', 'scanner_queue.json');
+  const queued = JSON.parse(fs.readFileSync(queuePath, 'utf-8')) as ScoredMarket[];
+
+  const reports = queued.map((market) => {
+    const confidence = confidenceFromEdge(market.estimatedEdge);
+    const riskFlags = [
+      ...(market.spread > config.scanner.maxSpread * 0.8 ? ['wider_spread_watch'] : []),
+      ...(market.liquidity < config.scanner.minLiquidity * 1.25 ? ['borderline_liquidity'] : [])
+    ];
+
+    const pass = market.estimatedEdge >= config.research.passEdge && confidence >= config.research.minConfidence;
+
+    return {
+      market_id: market.id,
+      question: market.question,
+      current_price: market.currentPrice,
+      estimated_probability: market.estimatedProbability,
+      edge: market.estimatedEdge,
+      confidence,
+      reasoning_summary:
+        'Deterministic placeholder model: combines market price with liquidity/volume signals and simple risk checks.',
+      risk_flags: riskFlags,
+      pass
+    };
+  });
+
+  const outputPath = path.resolve(process.cwd(), 'data', 'research_output.json');
+  fs.writeFileSync(outputPath, JSON.stringify(reports, null, 2));
+
+  return reports;
+};

--- a/paper-trading-mvp/src/agents/risk.ts
+++ b/paper-trading-mvp/src/agents/risk.ts
@@ -1,0 +1,45 @@
+import { AppConfig } from '../config/defaultConfig';
+import { StrategyDecision } from '../types/signal';
+
+export interface SizedDecision extends StrategyDecision {
+  sizeUsd: number;
+  allowed: boolean;
+  rejectionReason?: string;
+}
+
+export const sizeDecision = (
+  decision: StrategyDecision,
+  bankroll: number,
+  estimatedEdge: number,
+  dailyPnl: number,
+  openPositions: number,
+  config: AppConfig
+): SizedDecision => {
+  if (decision.direction === 'none' || decision.desiredExposure <= 0) {
+    return { ...decision, sizeUsd: 0, allowed: false, rejectionReason: 'no_trade_signal' };
+  }
+
+  if (dailyPnl <= -config.risk.maxDailyLoss) {
+    return { ...decision, sizeUsd: 0, allowed: false, rejectionReason: 'max_daily_loss_hit' };
+  }
+
+  if (openPositions >= config.risk.maxOpenPositions) {
+    return { ...decision, sizeUsd: 0, allowed: false, rejectionReason: 'max_open_positions_hit' };
+  }
+
+  // Capped Kelly approximation using edge as proxy for expected advantage.
+  const rawKelly = estimatedEdge / Math.max(0.2, 1 - estimatedEdge);
+  const fStar = Math.max(0, Math.min(rawKelly * config.risk.cappedKellyFraction, 0.25));
+  if (fStar <= 0) {
+    return { ...decision, sizeUsd: 0, allowed: false, rejectionReason: 'f_star_non_positive' };
+  }
+
+  const sizeUsd = Math.min(bankroll * fStar * decision.desiredExposure, config.risk.maxPositionSize, bankroll * 0.2);
+
+  return {
+    ...decision,
+    sizeUsd,
+    allowed: sizeUsd > 0,
+    rejectionReason: sizeUsd > 0 ? undefined : 'size_below_zero'
+  };
+};

--- a/paper-trading-mvp/src/agents/risk.ts
+++ b/paper-trading-mvp/src/agents/risk.ts
@@ -15,6 +15,13 @@ export const sizeDecision = (
   openPositions: number,
   config: AppConfig
 ): SizedDecision => {
+  if (!Number.isFinite(bankroll) || bankroll <= 0) {
+    throw new Error('Invalid bankroll for risk sizing.');
+  }
+  if (!Number.isFinite(estimatedEdge)) {
+    throw new Error('Invalid estimated edge for risk sizing.');
+  }
+
   if (decision.direction === 'none' || decision.desiredExposure <= 0) {
     return { ...decision, sizeUsd: 0, allowed: false, rejectionReason: 'no_trade_signal' };
   }
@@ -27,7 +34,6 @@ export const sizeDecision = (
     return { ...decision, sizeUsd: 0, allowed: false, rejectionReason: 'max_open_positions_hit' };
   }
 
-  // Capped Kelly approximation using edge as proxy for expected advantage.
   const rawKelly = estimatedEdge / Math.max(0.2, 1 - estimatedEdge);
   const fStar = Math.max(0, Math.min(rawKelly * config.risk.cappedKellyFraction, 0.25));
   if (fStar <= 0) {

--- a/paper-trading-mvp/src/agents/scanner.ts
+++ b/paper-trading-mvp/src/agents/scanner.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { AppConfig } from '../config/defaultConfig';
+import { Market, ScoredMarket } from '../types/market';
+
+const estimateProbability = (market: Market): number => {
+  // Deterministic placeholder: blend current price with liquidity/volume signal.
+  const liquiditySignal = Math.min(0.15, market.liquidity / 1_000_000);
+  const volumeSignal = Math.min(0.08, market.volume24h / 1_000_000);
+  return Math.max(0.01, Math.min(0.99, market.currentPrice + liquiditySignal - volumeSignal / 2));
+};
+
+export const runScanner = (markets: Market[], config: AppConfig): ScoredMarket[] => {
+  const now = Date.now();
+  const results = markets.map((market) => {
+    const estimatedProbability = estimateProbability(market);
+    const estimatedEdge = Math.abs(estimatedProbability - market.currentPrice);
+    const hoursToResolution = (new Date(market.resolutionAt).getTime() - now) / (1000 * 60 * 60);
+
+    const checks: Array<[boolean, string]> = [
+      [market.liquidity >= config.scanner.minLiquidity, 'insufficient_liquidity'],
+      [market.spread <= config.scanner.maxSpread, 'spread_too_wide'],
+      [hoursToResolution >= config.scanner.minHoursToResolution, 'too_close_to_resolution'],
+      [hoursToResolution <= config.scanner.maxHoursToResolution, 'too_far_to_resolution'],
+      [config.scanner.categoryAllowList.includes(market.category as never), 'not_in_allow_list'],
+      [!config.scanner.categoryBlockList.includes(market.category as never), 'in_block_list'],
+      [estimatedEdge >= config.scanner.minEstimatedEdge, 'edge_too_small']
+    ];
+
+    const scannerReasons = checks.filter(([pass]) => !pass).map(([, reason]) => reason);
+
+    return {
+      ...market,
+      estimatedProbability,
+      estimatedEdge,
+      scannerPass: scannerReasons.length === 0,
+      scannerReasons
+    };
+  });
+
+  const queue = results.filter((m) => m.scannerPass);
+  const queuePath = path.resolve(process.cwd(), 'data', 'scanner_queue.json');
+  fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2));
+
+  return results;
+};

--- a/paper-trading-mvp/src/agents/scanner.ts
+++ b/paper-trading-mvp/src/agents/scanner.ts
@@ -1,16 +1,17 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { AppConfig } from '../config/defaultConfig';
 import { Market, ScoredMarket } from '../types/market';
+import { writeJson } from '../utils/io';
 
 const estimateProbability = (market: Market): number => {
-  // Deterministic placeholder: blend current price with liquidity/volume signal.
   const liquiditySignal = Math.min(0.15, market.liquidity / 1_000_000);
   const volumeSignal = Math.min(0.08, market.volume24h / 1_000_000);
   return Math.max(0.01, Math.min(0.99, market.currentPrice + liquiditySignal - volumeSignal / 2));
 };
 
 export const runScanner = (markets: Market[], config: AppConfig): ScoredMarket[] => {
+  if (markets.length === 0) throw new Error('Scanner received no markets to evaluate.');
+
   const now = Date.now();
   const results = markets.map((market) => {
     const estimatedProbability = estimateProbability(market);
@@ -22,8 +23,8 @@ export const runScanner = (markets: Market[], config: AppConfig): ScoredMarket[]
       [market.spread <= config.scanner.maxSpread, 'spread_too_wide'],
       [hoursToResolution >= config.scanner.minHoursToResolution, 'too_close_to_resolution'],
       [hoursToResolution <= config.scanner.maxHoursToResolution, 'too_far_to_resolution'],
-      [config.scanner.categoryAllowList.includes(market.category as never), 'not_in_allow_list'],
-      [!config.scanner.categoryBlockList.includes(market.category as never), 'in_block_list'],
+      [config.scanner.categoryAllowList.includes(market.category), 'not_in_allow_list'],
+      [!config.scanner.categoryBlockList.includes(market.category), 'in_block_list'],
       [estimatedEdge >= config.scanner.minEstimatedEdge, 'edge_too_small']
     ];
 
@@ -39,8 +40,8 @@ export const runScanner = (markets: Market[], config: AppConfig): ScoredMarket[]
   });
 
   const queue = results.filter((m) => m.scannerPass);
-  const queuePath = path.resolve(process.cwd(), 'data', 'scanner_queue.json');
-  fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2));
+  const queuePath = path.resolve(process.cwd(), config.engine.artifactsDir, 'scanner_queue.json');
+  writeJson(queuePath, queue);
 
   return results;
 };

--- a/paper-trading-mvp/src/agents/strategy.ts
+++ b/paper-trading-mvp/src/agents/strategy.ts
@@ -1,0 +1,61 @@
+import { AppConfig } from '../config/defaultConfig';
+import { ScoredMarket } from '../types/market';
+import { ResearchReport, StrategyDecision } from '../types/signal';
+import { WalletScore } from '../types/wallet';
+
+const walletDirectionalBias = (wallets: WalletScore[]): 'yes' | 'no' | 'none' => {
+  if (!wallets.length) return 'none';
+  const avgWinRate = wallets.reduce((sum, w) => sum + w.winRate, 0) / wallets.length;
+  if (avgWinRate >= 0.55) return 'yes';
+  if (avgWinRate <= 0.45) return 'no';
+  return 'none';
+};
+
+export const buildStrategyDecisions = (
+  scanned: ScoredMarket[],
+  researchReports: ResearchReport[],
+  wallets: WalletScore[],
+  config: AppConfig
+): StrategyDecision[] => {
+  const researchByMarket = new Map(researchReports.map((r) => [r.market_id, r]));
+  const walletBias = walletDirectionalBias(wallets);
+
+  return scanned
+    .filter((m) => m.scannerPass)
+    .map((market) => {
+      const report = researchByMarket.get(market.id);
+      const scannerSignal = market.estimatedProbability > market.currentPrice ? 'yes' : 'no';
+      const researchSignal = report && report.pass ? (report.estimated_probability > report.current_price ? 'yes' : 'no') : 'none';
+
+      const signals = [scannerSignal, researchSignal, walletBias].filter((s) => s !== 'none');
+      const yesVotes = signals.filter((s) => s === 'yes').length;
+      const noVotes = signals.filter((s) => s === 'no').length;
+      const consensusCount = Math.max(yesVotes, noVotes);
+
+      if (consensusCount < 2) {
+        return {
+          marketId: market.id,
+          direction: 'none',
+          strategy: 'none',
+          consensusCount,
+          confidence: 0,
+          desiredExposure: 0,
+          rationale: 'Insufficient agreement among scanner/research/wallet signals.'
+        } satisfies StrategyDecision;
+      }
+
+      const direction = yesVotes > noVotes ? 'yes' : 'no';
+      const desiredExposure =
+        consensusCount >= 2 ? config.strategy.fullPositionExposure : config.strategy.halfPositionExposure;
+
+      return {
+        marketId: market.id,
+        direction,
+        strategy: 'convergence',
+        consensusCount,
+        confidence: 0.5 + consensusCount * 0.15,
+        desiredExposure,
+        rationale: `Consensus ${consensusCount}/3 with ${direction.toUpperCase()} bias.`
+      } satisfies StrategyDecision;
+    });
+};

--- a/paper-trading-mvp/src/agents/strategy.ts
+++ b/paper-trading-mvp/src/agents/strategy.ts
@@ -32,7 +32,7 @@ export const buildStrategyDecisions = (
       const noVotes = signals.filter((s) => s === 'no').length;
       const consensusCount = Math.max(yesVotes, noVotes);
 
-      if (consensusCount < 2) {
+      if (signals.length === 0 || (yesVotes > 0 && noVotes > 0 && consensusCount < 2)) {
         return {
           marketId: market.id,
           direction: 'none',
@@ -40,21 +40,31 @@ export const buildStrategyDecisions = (
           consensusCount,
           confidence: 0,
           desiredExposure: 0,
-          rationale: 'Insufficient agreement among scanner/research/wallet signals.'
+          rationale: 'Disagreement among scanner/research/wallet signals.'
+        } satisfies StrategyDecision;
+      }
+
+      if (consensusCount === 1) {
+        const direction = yesVotes === 1 ? 'yes' : 'no';
+        return {
+          marketId: market.id,
+          direction,
+          strategy: 'copy_trade_placeholder',
+          consensusCount,
+          confidence: 0.55,
+          desiredExposure: config.strategy.halfPositionExposure,
+          rationale: `Single-signal ${direction.toUpperCase()} bias: half exposure.`
         } satisfies StrategyDecision;
       }
 
       const direction = yesVotes > noVotes ? 'yes' : 'no';
-      const desiredExposure =
-        consensusCount >= 2 ? config.strategy.fullPositionExposure : config.strategy.halfPositionExposure;
-
       return {
         marketId: market.id,
         direction,
         strategy: 'convergence',
         consensusCount,
         confidence: 0.5 + consensusCount * 0.15,
-        desiredExposure,
+        desiredExposure: config.strategy.fullPositionExposure,
         rationale: `Consensus ${consensusCount}/3 with ${direction.toUpperCase()} bias.`
       } satisfies StrategyDecision;
     });

--- a/paper-trading-mvp/src/agents/strategy.ts
+++ b/paper-trading-mvp/src/agents/strategy.ts
@@ -1,6 +1,6 @@
 import { AppConfig } from '../config/defaultConfig';
 import { ScoredMarket } from '../types/market';
-import { ResearchReport, StrategyDecision } from '../types/signal';
+import { LlmResearchReport, ResearchReport, StrategyDecision } from '../types/signal';
 import { WalletScore } from '../types/wallet';
 
 const walletDirectionalBias = (wallets: WalletScore[]): 'yes' | 'no' | 'none' => {
@@ -15,19 +15,23 @@ export const buildStrategyDecisions = (
   scanned: ScoredMarket[],
   researchReports: ResearchReport[],
   wallets: WalletScore[],
-  config: AppConfig
+  config: AppConfig,
+  llmReports: LlmResearchReport[] = []
 ): StrategyDecision[] => {
   const researchByMarket = new Map(researchReports.map((r) => [r.market_id, r]));
+  const llmByMarket = new Map(llmReports.map((r) => [r.marketId, r]));
   const walletBias = walletDirectionalBias(wallets);
 
   return scanned
     .filter((m) => m.scannerPass)
     .map((market) => {
       const report = researchByMarket.get(market.id);
+      const llm = llmByMarket.get(market.id);
       const scannerSignal = market.estimatedProbability > market.currentPrice ? 'yes' : 'no';
       const researchSignal = report && report.pass ? (report.estimated_probability > report.current_price ? 'yes' : 'no') : 'none';
+      const llmSignal = llm && llm.pass ? (llm.estimatedProbability > market.currentPrice ? 'yes' : 'no') : 'none';
 
-      const signals = [scannerSignal, researchSignal, walletBias].filter((s) => s !== 'none');
+      const signals = [scannerSignal, researchSignal, walletBias, llmSignal].filter((s) => s !== 'none');
       const yesVotes = signals.filter((s) => s === 'yes').length;
       const noVotes = signals.filter((s) => s === 'no').length;
       const consensusCount = Math.max(yesVotes, noVotes);
@@ -40,7 +44,7 @@ export const buildStrategyDecisions = (
           consensusCount,
           confidence: 0,
           desiredExposure: 0,
-          rationale: 'Disagreement among scanner/research/wallet signals.'
+          rationale: 'Disagreement among scanner/research/wallet/llm signals.'
         } satisfies StrategyDecision;
       }
 
@@ -63,9 +67,9 @@ export const buildStrategyDecisions = (
         direction,
         strategy: 'convergence',
         consensusCount,
-        confidence: 0.5 + consensusCount * 0.15,
+        confidence: 0.5 + consensusCount * 0.12,
         desiredExposure: config.strategy.fullPositionExposure,
-        rationale: `Consensus ${consensusCount}/3 with ${direction.toUpperCase()} bias.`
+        rationale: `Consensus ${consensusCount}/4 with ${direction.toUpperCase()} bias.`
       } satisfies StrategyDecision;
     });
 };

--- a/paper-trading-mvp/src/agents/walletIntel.ts
+++ b/paper-trading-mvp/src/agents/walletIntel.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { AppConfig } from '../config/defaultConfig';
+import { WalletScore, WalletTrade } from '../types/wallet';
+
+const computeDrawdown = (profits: number[]): number => {
+  let peak = 0;
+  let equity = 0;
+  let maxDrawdown = 0;
+  for (const p of profits) {
+    equity += p;
+    peak = Math.max(peak, equity);
+    maxDrawdown = Math.max(maxDrawdown, peak - equity);
+  }
+  return maxDrawdown;
+};
+
+export const rankWallets = (trades: WalletTrade[], config: AppConfig): WalletScore[] => {
+  const grouped = new Map<string, WalletTrade[]>();
+  for (const trade of trades) {
+    const arr = grouped.get(trade.wallet) ?? [];
+    arr.push(trade);
+    grouped.set(trade.wallet, arr);
+  }
+
+  const scores: WalletScore[] = Array.from(grouped.entries()).map(([wallet, walletTrades]) => {
+    const numberOfTrades = walletTrades.length;
+    const profits = walletTrades.map((t) => t.payout - t.stake);
+    const wins = profits.filter((p) => p > 0).length;
+    const winRate = numberOfTrades ? wins / numberOfTrades : 0;
+    const realizedProfit = profits.reduce((a, b) => a + b, 0);
+    const maxDrawdown = computeDrawdown(profits);
+
+    const catCounts = new Map<string, number>();
+    for (const t of walletTrades) catCounts.set(t.category, (catCounts.get(t.category) ?? 0) + 1);
+    const largestCategory = Math.max(...Array.from(catCounts.values()));
+    const categoryConsistency = largestCategory / numberOfTrades;
+
+    const trustedSample = numberOfTrades >= config.walletIntel.minTradesForTrust;
+    const samplePenalty = trustedSample ? 1 : Math.max(0.3, numberOfTrades / config.walletIntel.minTradesForTrust);
+
+    const rankScore =
+      (winRate * 40 + realizedProfit / 20 + categoryConsistency * 20 - maxDrawdown / 25) * samplePenalty;
+
+    return {
+      wallet,
+      numberOfTrades,
+      winRate,
+      realizedProfit,
+      maxDrawdown,
+      categoryConsistency,
+      trustedSample,
+      rankScore
+    };
+  });
+
+  const sorted = scores.sort((a, b) => b.rankScore - a.rankScore).slice(0, config.walletIntel.topN);
+  const outputPath = path.resolve(process.cwd(), 'data', 'top_wallets.json');
+  fs.writeFileSync(outputPath, JSON.stringify(sorted, null, 2));
+  return sorted;
+};

--- a/paper-trading-mvp/src/agents/walletIntel.ts
+++ b/paper-trading-mvp/src/agents/walletIntel.ts
@@ -1,7 +1,7 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { AppConfig } from '../config/defaultConfig';
 import { WalletScore, WalletTrade } from '../types/wallet';
+import { writeJson } from '../utils/io';
 
 const computeDrawdown = (profits: number[]): number => {
   let peak = 0;
@@ -55,7 +55,7 @@ export const rankWallets = (trades: WalletTrade[], config: AppConfig): WalletSco
   });
 
   const sorted = scores.sort((a, b) => b.rankScore - a.rankScore).slice(0, config.walletIntel.topN);
-  const outputPath = path.resolve(process.cwd(), 'data', 'top_wallets.json');
-  fs.writeFileSync(outputPath, JSON.stringify(sorted, null, 2));
+  const outputPath = path.resolve(process.cwd(), config.engine.artifactsDir, 'top_wallets.json');
+  writeJson(outputPath, sorted);
   return sorted;
 };

--- a/paper-trading-mvp/src/agents/walletIntel.ts
+++ b/paper-trading-mvp/src/agents/walletIntel.ts
@@ -24,38 +24,52 @@ export const rankWallets = (trades: WalletTrade[], config: AppConfig): WalletSco
   }
 
   const scores: WalletScore[] = Array.from(grouped.entries()).map(([wallet, walletTrades]) => {
-    const numberOfTrades = walletTrades.length;
+    const totalTrades = walletTrades.length;
     const profits = walletTrades.map((t) => t.payout - t.stake);
     const wins = profits.filter((p) => p > 0).length;
-    const winRate = numberOfTrades ? wins / numberOfTrades : 0;
-    const realizedProfit = profits.reduce((a, b) => a + b, 0);
+    const winRate = totalTrades ? wins / totalTrades : 0;
+    const realizedPnl = profits.reduce((a, b) => a + b, 0);
+    const totalStake = walletTrades.reduce((sum, t) => sum + t.stake, 0);
+    const roi = totalStake > 0 ? realizedPnl / totalStake : 0;
+    const averageTradeSize = totalTrades > 0 ? totalStake / totalTrades : 0;
     const maxDrawdown = computeDrawdown(profits);
 
     const catCounts = new Map<string, number>();
     for (const t of walletTrades) catCounts.set(t.category, (catCounts.get(t.category) ?? 0) + 1);
     const largestCategory = Math.max(...Array.from(catCounts.values()));
-    const categoryConsistency = largestCategory / numberOfTrades;
+    const categoryConcentration = largestCategory / totalTrades;
 
-    const trustedSample = numberOfTrades >= config.walletIntel.minTradesForTrust;
-    const samplePenalty = trustedSample ? 1 : Math.max(0.3, numberOfTrades / config.walletIntel.minTradesForTrust);
+    const sampleSizeScore = Math.min(1, totalTrades / Math.max(1, config.walletIntel.minTradesForTrust));
+    const confidenceScore = Math.max(0, Math.min(1, sampleSizeScore * (0.6 + winRate * 0.4)));
+    const trustedSample = sampleSizeScore >= 1;
 
     const rankScore =
-      (winRate * 40 + realizedProfit / 20 + categoryConsistency * 20 - maxDrawdown / 25) * samplePenalty;
+      winRate * 25 + roi * 30 + realizedPnl / 25 + confidenceScore * 20 - maxDrawdown / 25 - categoryConcentration * 2;
 
     return {
       wallet,
-      numberOfTrades,
+      totalTrades,
       winRate,
-      realizedProfit,
+      realizedPnl,
+      roi,
+      averageTradeSize,
       maxDrawdown,
-      categoryConsistency,
+      categoryConcentration,
+      confidenceScore,
       trustedSample,
       rankScore
     };
   });
 
-  const sorted = scores.sort((a, b) => b.rankScore - a.rankScore).slice(0, config.walletIntel.topN);
-  const outputPath = path.resolve(process.cwd(), config.engine.artifactsDir, 'top_wallets.json');
+  const filtered = scores.filter(
+    (s) =>
+      s.totalTrades >= config.walletIntel.minTrades &&
+      s.realizedPnl >= config.walletIntel.minRealizedPnl &&
+      s.confidenceScore >= config.walletIntel.minConfidenceScore
+  );
+
+  const sorted = filtered.sort((a, b) => b.rankScore - a.rankScore).slice(0, config.walletIntel.topN);
+  const outputPath = path.resolve(process.cwd(), config.engine.artifactsDir, 'wallet_rankings.json');
   writeJson(outputPath, sorted);
   return sorted;
 };

--- a/paper-trading-mvp/src/analysis/compareRuns.ts
+++ b/paper-trading-mvp/src/analysis/compareRuns.ts
@@ -1,0 +1,74 @@
+import path from 'node:path';
+import { defaultConfig, mergeConfig } from '../config/defaultConfig';
+import { loadMarkets } from '../data/marketSource';
+import { loadTradeHistory } from '../data/polymarketTradeHistorySource';
+import { runBacktest } from '../backtest/engine';
+import { readJson, writeJson } from '../utils/io';
+
+interface RunMetrics {
+  roi: number;
+  winRate: number;
+  maxDrawdown: number;
+  tradeCount: number;
+  rejectionRate: number;
+}
+
+const summarize = (artifactsDir: string, backtest: ReturnType<typeof runBacktest>): RunMetrics => {
+  const rejections = readJson(path.resolve(process.cwd(), artifactsDir, 'guardrail_rejections.json')) as Array<{ marketId: string }>;
+  const rejectedCount = rejections.length;
+  const acceptedCount = backtest.tradeResults.length;
+  const totalReviewed = Math.max(1, rejectedCount + acceptedCount);
+
+  return {
+    roi: backtest.summary.roi,
+    winRate: backtest.summary.winRate,
+    maxDrawdown: backtest.summary.maxDrawdown,
+    tradeCount: acceptedCount,
+    rejectionRate: rejectedCount / totalReviewed
+  };
+};
+
+const main = () => {
+  const sampleConfig = mergeConfig(defaultConfig, { engine: { ...defaultConfig.engine, artifactsDir: 'artifacts/sample_run' } });
+  const realConfig = mergeConfig(defaultConfig, { engine: { ...defaultConfig.engine, artifactsDir: 'artifacts/real_run' } });
+
+  const sampleResult = runBacktest(loadMarkets('./data/sample_markets.json'), loadTradeHistory('json', './data/sample_trades.json', sampleConfig), sampleConfig);
+  const realResult = runBacktest(loadMarkets('./data/real_markets.json'), loadTradeHistory('json', './data/real_trades.json', realConfig), realConfig);
+
+  const sample = summarize(sampleConfig.engine.artifactsDir, sampleResult);
+  const real = summarize(realConfig.engine.artifactsDir, realResult);
+
+  const reasons: string[] = [];
+  if (real.roi < sample.roi * 0.5) reasons.push('real ROI is materially below sample ROI');
+  if (realResult.testSummary.roi < 0) reasons.push('test ROI is negative on real data');
+  if (real.rejectionRate > 0.8) reasons.push('guardrail rejection rate is above 80% on real data');
+  if (real.tradeCount === 0) reasons.push('no executable trades on real data');
+
+  const verdict = reasons.length === 0 ? (real.roi > 0 ? 'YES' : 'WEAK') : 'NO';
+  const noSignalDetected = verdict === 'NO';
+
+  if (noSignalDetected) {
+    console.warn(`NO SIGNAL DETECTED: ${reasons.join('; ')}`);
+  }
+
+  const comparison = {
+    generatedAt: new Date().toISOString(),
+    sample,
+    real,
+    delta: {
+      roi: real.roi - sample.roi,
+      winRate: real.winRate - sample.winRate,
+      maxDrawdown: real.maxDrawdown - sample.maxDrawdown,
+      tradeCount: real.tradeCount - sample.tradeCount,
+      rejectionRate: real.rejectionRate - sample.rejectionRate
+    },
+    verdict,
+    noSignalDetected,
+    reasons
+  };
+
+  writeJson(path.resolve(process.cwd(), 'artifacts', 'comparison_summary.json'), comparison);
+  console.log('Wrote artifacts/comparison_summary.json');
+};
+
+main();

--- a/paper-trading-mvp/src/backtest/engine.ts
+++ b/paper-trading-mvp/src/backtest/engine.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { sizeDecision } from '../agents/risk';
 import { runScanner } from '../agents/scanner';
 import { runResearch } from '../agents/research';
 import { buildStrategyDecisions } from '../agents/strategy';
@@ -32,11 +33,47 @@ const splitTrainTest = (trades: BacktestTradeResult[]) => {
   };
 };
 
+interface NearMiss {
+  marketId: string;
+  question: string;
+  failedStage: string;
+  failedReason: string;
+  liquidity: number;
+  spread: number;
+  edge: number;
+  edgeAfterSlippage: number;
+  timeToResolutionHours: number;
+  walletSignal: number;
+}
+
+interface PipelineDiagnostics {
+  generatedAt: string;
+  funnel: {
+    marketsLoaded: number;
+    scannerPassed: number;
+    researchPassed: number;
+    walletSignalsAvailable: number;
+    strategyCandidates: number;
+    riskApproved: number;
+    guardrailApproved: number;
+    executedTrades: number;
+  };
+  rejectionCountsByStage: Record<string, number>;
+  rejectionReasonsByStage: Record<string, Record<string, number>>;
+  topBlockers: Array<{ stage: string; reason: string; count: number }>;
+  nearMissCandidates: NearMiss[];
+}
+
+const incrementReason = (obj: Record<string, number>, reason: string): void => {
+  obj[reason] = (obj[reason] ?? 0) + 1;
+};
+
 export const runBacktest = (markets: any[], trades: WalletTrade[], config: AppConfig) => {
   assertHistoricalData(markets, trades);
 
   const scanned = runScanner(markets, config);
   const research = runResearch(config);
+  const researchByMarket = new Map(research.map((r) => [r.market_id, r]));
   const walletScores = rankWallets(trades, config);
   const decisions = buildStrategyDecisions(scanned, research, walletScores, config);
 
@@ -45,32 +82,114 @@ export const runBacktest = (markets: any[], trades: WalletTrade[], config: AppCo
   const tradeResults: BacktestTradeResult[] = [];
   const rejections: Array<{ marketId: string; reasons: string[] }> = [];
 
-  for (const decision of decisions) {
-    if (decision.direction === 'none') continue;
-    const market = scanned.find((m) => m.id === decision.marketId);
-    if (!market) continue;
+  const stageRejected: Record<string, number> = {
+    scanner: 0,
+    research: 0,
+    strategy: 0,
+    risk: 0,
+    guardrail: 0,
+    execution: 0
+  };
+  const stageReasons: Record<string, Record<string, number>> = {
+    scanner: {},
+    research: {},
+    strategy: {},
+    risk: {},
+    guardrail: {},
+    execution: {}
+  };
+
+  const nearMissCandidates: NearMiss[] = [];
+
+  const scannerPassed = scanned.filter((m) => m.scannerPass);
+  const researchPassedSet = new Set(research.filter((r) => r.pass).map((r) => r.market_id));
+  const strategyCandidates = decisions.filter((d) => d.direction !== 'none');
+
+  let riskApproved = 0;
+  let guardrailApproved = 0;
+
+  for (const market of scanned) {
+    const decision = decisions.find((d) => d.marketId === market.id);
+    const researchReport = researchByMarket.get(market.id);
+    const timeToResolutionHours = (new Date(market.resolutionAt).getTime() - Date.now()) / 3_600_000;
+    const walletSignal = walletScores.length > 0 ? Math.max(...walletScores.map((w) => w.confidenceScore)) : 0;
+
+    const addNearMiss = (failedStage: string, failedReason: string, edgeAfterSlippage = market.estimatedEdge): void => {
+      nearMissCandidates.push({
+        marketId: market.id,
+        question: market.question,
+        failedStage,
+        failedReason,
+        liquidity: market.liquidity,
+        spread: market.spread,
+        edge: market.estimatedEdge,
+        edgeAfterSlippage,
+        timeToResolutionHours,
+        walletSignal
+      });
+    };
+
+    if (!market.scannerPass) {
+      stageRejected.scanner += 1;
+      market.scannerReasons.forEach((reason) => incrementReason(stageReasons.scanner, reason));
+      addNearMiss('scanner', market.scannerReasons[0] ?? 'scanner_rejected');
+      continue;
+    }
+
+    if (!researchReport || !researchReport.pass) {
+      stageRejected.research += 1;
+      const reason = !researchReport ? 'missing_research_report' : 'research_confidence_or_edge_below_threshold';
+      incrementReason(stageReasons.research, reason);
+      addNearMiss('research', reason);
+      continue;
+    }
+
+    if (!decision || decision.direction === 'none') {
+      stageRejected.strategy += 1;
+      const reason = decision?.rationale ?? 'no_strategy_decision';
+      incrementReason(stageReasons.strategy, reason);
+      addNearMiss('strategy', reason);
+      continue;
+    }
+
+    const sized = sizeDecision(decision, bankroll, market.estimatedEdge, 0, tradeResults.length, config);
+    if (!sized.allowed || sized.sizeUsd <= 0) {
+      stageRejected.risk += 1;
+      const reason = sized.rejectionReason ?? 'risk_rejected';
+      incrementReason(stageReasons.risk, reason);
+      addNearMiss('risk', reason);
+      continue;
+    }
+    riskApproved += 1;
+
+    const guard = evaluateStrategyGuards(market, decision, sized.sizeUsd, walletScores, config);
+    if (!guard.allowed) {
+      stageRejected.guardrail += 1;
+      guard.reasons.forEach((reason) => incrementReason(stageReasons.guardrail, reason));
+      addNearMiss('guardrail', guard.reasons[0] ?? 'guardrail_rejected', guard.slippage.edgeAfterSlippage);
+      rejections.push({ marketId: market.id, reasons: guard.reasons });
+      continue;
+    }
+    guardrailApproved += 1;
 
     const related = trades
       .filter((t) => t.marketId === market.id)
       .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
 
-    if (related.length === 0) continue;
-
-    const positionSize = Math.min(config.risk.maxPositionSize, bankroll * 0.05);
-    const guard = evaluateStrategyGuards(market, decision, positionSize, walletScores, config);
-    if (!guard.allowed) {
-      rejections.push({ marketId: market.id, reasons: guard.reasons });
+    if (related.length === 0) {
+      stageRejected.execution += 1;
+      incrementReason(stageReasons.execution, 'no_related_trades_for_market');
+      addNearMiss('execution', 'no_related_trades_for_market', guard.slippage.edgeAfterSlippage);
       continue;
     }
 
     const totalStake = related.reduce((sum, t) => sum + t.stake, 0);
     const totalPayout = related.reduce((sum, t) => sum + t.payout, 0);
     const marketReturn = totalStake > 0 ? (totalPayout - totalStake) / totalStake : 0;
-    if (positionSize <= 0) continue;
 
     const signedReturn = decision.direction === 'yes' ? marketReturn : -marketReturn;
-    const pnl = positionSize * signedReturn;
-    const roi = positionSize > 0 ? pnl / positionSize : 0;
+    const pnl = sized.sizeUsd * signedReturn;
+    const roi = sized.sizeUsd > 0 ? pnl / sized.sizeUsd : 0;
 
     bankroll += pnl;
     equityCurve.push(bankroll);
@@ -84,11 +203,44 @@ export const runBacktest = (markets: any[], trades: WalletTrade[], config: AppCo
 
   const summary = calculateBacktestMetrics(tradeResults, config.engine.startingBankroll, bankroll, equityCurve);
   const { train, test } = splitTrainTest(tradeResults);
-  const trainSummary = calculateBacktestMetrics(train, config.engine.startingBankroll, config.engine.startingBankroll + train.reduce((s, t) => s + t.pnl, 0), [config.engine.startingBankroll, config.engine.startingBankroll + train.reduce((s, t) => s + t.pnl, 0)]);
+  const trainSummary = calculateBacktestMetrics(
+    train,
+    config.engine.startingBankroll,
+    config.engine.startingBankroll + train.reduce((s, t) => s + t.pnl, 0),
+    [config.engine.startingBankroll, config.engine.startingBankroll + train.reduce((s, t) => s + t.pnl, 0)]
+  );
   const testStart = config.engine.startingBankroll + train.reduce((s, t) => s + t.pnl, 0);
-  const testSummary = calculateBacktestMetrics(test, testStart, testStart + test.reduce((s, t) => s + t.pnl, 0), [testStart, testStart + test.reduce((s, t) => s + t.pnl, 0)]);
+  const testSummary = calculateBacktestMetrics(
+    test,
+    testStart,
+    testStart + test.reduce((s, t) => s + t.pnl, 0),
+    [testStart, testStart + test.reduce((s, t) => s + t.pnl, 0)]
+  );
 
   const overfitWarning = trainSummary.roi > 0.1 && testSummary.roi < 0.02;
+
+  const topBlockers = Object.entries(stageReasons)
+    .flatMap(([stage, reasons]) => Object.entries(reasons).map(([reason, count]) => ({ stage, reason, count })))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+
+  const pipelineDiagnostics: PipelineDiagnostics = {
+    generatedAt: new Date().toISOString(),
+    funnel: {
+      marketsLoaded: markets.length,
+      scannerPassed: scannerPassed.length,
+      researchPassed: researchPassedSet.size,
+      walletSignalsAvailable: walletScores.length,
+      strategyCandidates: strategyCandidates.length,
+      riskApproved,
+      guardrailApproved,
+      executedTrades: tradeResults.length
+    },
+    rejectionCountsByStage: stageRejected,
+    rejectionReasonsByStage: stageReasons,
+    topBlockers,
+    nearMissCandidates: nearMissCandidates.sort((a, b) => b.edgeAfterSlippage - a.edgeAfterSlippage).slice(0, 20)
+  };
 
   const artifact = {
     mode: 'backtest',
@@ -100,13 +252,15 @@ export const runBacktest = (markets: any[], trades: WalletTrade[], config: AppCo
     summary,
     trainSummary,
     testSummary,
-    overfitWarning
+    overfitWarning,
+    pipelineDiagnostics
   };
 
   writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'backtest_summary.json'), artifact);
   writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'backtest_train_summary.json'), trainSummary);
   writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'backtest_test_summary.json'), testSummary);
   writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'guardrail_rejections.json'), rejections);
+  writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'pipeline_diagnostics.json'), pipelineDiagnostics);
 
   return artifact;
 };

--- a/paper-trading-mvp/src/backtest/engine.ts
+++ b/paper-trading-mvp/src/backtest/engine.ts
@@ -1,0 +1,96 @@
+import path from 'node:path';
+import { runScanner } from '../agents/scanner';
+import { runResearch } from '../agents/research';
+import { buildStrategyDecisions } from '../agents/strategy';
+import { rankWallets } from '../agents/walletIntel';
+import { AppConfig } from '../config/defaultConfig';
+import { Market } from '../types/market';
+import { WalletTrade } from '../types/wallet';
+import { writeJson } from '../utils/io';
+import { BacktestTradeResult, calculateBacktestMetrics } from './metrics';
+
+const assertHistoricalData = (markets: Market[], trades: WalletTrade[]): void => {
+  if (markets.length === 0) throw new Error('Backtest requires at least one historical market.');
+  if (trades.length === 0) throw new Error('Backtest requires at least one historical trade/fill.');
+  for (const trade of trades) {
+    if (!Number.isFinite(trade.stake) || !Number.isFinite(trade.payout)) {
+      throw new Error('Malformed historical trade: invalid stake or payout value.');
+    }
+    if (Number.isNaN(new Date(trade.timestamp).getTime())) {
+      throw new Error('Malformed historical trade: invalid timestamp.');
+    }
+  }
+};
+
+export const runBacktest = (markets: Market[], trades: WalletTrade[], config: AppConfig) => {
+  assertHistoricalData(markets, trades);
+
+  const scanned = runScanner(markets, config);
+  const research = runResearch(config);
+  const walletScores = rankWallets(trades, config);
+  const decisions = buildStrategyDecisions(scanned, research, walletScores, config);
+
+  let bankroll = config.engine.startingBankroll;
+  const equityCurve = [bankroll];
+  const tradeResults: BacktestTradeResult[] = [];
+
+  for (const decision of decisions) {
+    if (decision.direction === 'none') continue;
+    const market = scanned.find((m) => m.id === decision.marketId);
+    if (!market) continue;
+
+    const related = trades
+      .filter((t) => t.marketId === market.id)
+      .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+    if (related.length === 0) continue;
+
+    const totalStake = related.reduce((sum, t) => sum + t.stake, 0);
+    const totalPayout = related.reduce((sum, t) => sum + t.payout, 0);
+    const marketReturn = totalStake > 0 ? (totalPayout - totalStake) / totalStake : 0;
+
+    const positionSize = Math.min(config.risk.maxPositionSize, bankroll * 0.05);
+    if (positionSize <= 0) continue;
+
+    const signedReturn = decision.direction === 'yes' ? marketReturn : -marketReturn;
+    const pnl = positionSize * signedReturn;
+    const roi = positionSize > 0 ? pnl / positionSize : 0;
+
+    bankroll += pnl;
+    equityCurve.push(bankroll);
+
+    const entryTime = related[0].timestamp;
+    const exitTime = related[related.length - 1].timestamp;
+    const holdingMs = Math.max(0, new Date(exitTime).getTime() - new Date(entryTime).getTime());
+
+    tradeResults.push({
+      marketId: market.id,
+      direction: decision.direction,
+      entryTime,
+      exitTime,
+      holdingMs,
+      pnl,
+      roi
+    });
+  }
+
+  const summary = calculateBacktestMetrics(
+    tradeResults,
+    config.engine.startingBankroll,
+    bankroll,
+    equityCurve
+  );
+
+  const artifact = {
+    mode: 'backtest',
+    source: config.marketSource,
+    tradeCountInput: trades.length,
+    scannedMarkets: scanned.length,
+    decisionCount: decisions.length,
+    tradeResults,
+    summary
+  };
+
+  writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'backtest_summary.json'), artifact);
+  return artifact;
+};

--- a/paper-trading-mvp/src/backtest/engine.ts
+++ b/paper-trading-mvp/src/backtest/engine.ts
@@ -4,12 +4,13 @@ import { runResearch } from '../agents/research';
 import { buildStrategyDecisions } from '../agents/strategy';
 import { rankWallets } from '../agents/walletIntel';
 import { AppConfig } from '../config/defaultConfig';
-import { Market } from '../types/market';
+import { ScoredMarket } from '../types/market';
 import { WalletTrade } from '../types/wallet';
 import { writeJson } from '../utils/io';
+import { evaluateStrategyGuards } from '../validation/strategyGuards';
 import { BacktestTradeResult, calculateBacktestMetrics } from './metrics';
 
-const assertHistoricalData = (markets: Market[], trades: WalletTrade[]): void => {
+const assertHistoricalData = (markets: ScoredMarket[] | any[], trades: WalletTrade[]): void => {
   if (markets.length === 0) throw new Error('Backtest requires at least one historical market.');
   if (trades.length === 0) throw new Error('Backtest requires at least one historical trade/fill.');
   for (const trade of trades) {
@@ -22,7 +23,16 @@ const assertHistoricalData = (markets: Market[], trades: WalletTrade[]): void =>
   }
 };
 
-export const runBacktest = (markets: Market[], trades: WalletTrade[], config: AppConfig) => {
+const splitTrainTest = (trades: BacktestTradeResult[]) => {
+  const sorted = [...trades].sort((a, b) => new Date(a.entryTime).getTime() - new Date(b.entryTime).getTime());
+  const splitIdx = Math.max(1, Math.floor(sorted.length * 0.7));
+  return {
+    train: sorted.slice(0, splitIdx),
+    test: sorted.slice(splitIdx)
+  };
+};
+
+export const runBacktest = (markets: any[], trades: WalletTrade[], config: AppConfig) => {
   assertHistoricalData(markets, trades);
 
   const scanned = runScanner(markets, config);
@@ -33,6 +43,7 @@ export const runBacktest = (markets: Market[], trades: WalletTrade[], config: Ap
   let bankroll = config.engine.startingBankroll;
   const equityCurve = [bankroll];
   const tradeResults: BacktestTradeResult[] = [];
+  const rejections: Array<{ marketId: string; reasons: string[] }> = [];
 
   for (const decision of decisions) {
     if (decision.direction === 'none') continue;
@@ -45,11 +56,16 @@ export const runBacktest = (markets: Market[], trades: WalletTrade[], config: Ap
 
     if (related.length === 0) continue;
 
+    const positionSize = Math.min(config.risk.maxPositionSize, bankroll * 0.05);
+    const guard = evaluateStrategyGuards(market, decision, positionSize, walletScores, config);
+    if (!guard.allowed) {
+      rejections.push({ marketId: market.id, reasons: guard.reasons });
+      continue;
+    }
+
     const totalStake = related.reduce((sum, t) => sum + t.stake, 0);
     const totalPayout = related.reduce((sum, t) => sum + t.payout, 0);
     const marketReturn = totalStake > 0 ? (totalPayout - totalStake) / totalStake : 0;
-
-    const positionSize = Math.min(config.risk.maxPositionSize, bankroll * 0.05);
     if (positionSize <= 0) continue;
 
     const signedReturn = decision.direction === 'yes' ? marketReturn : -marketReturn;
@@ -63,23 +79,16 @@ export const runBacktest = (markets: Market[], trades: WalletTrade[], config: Ap
     const exitTime = related[related.length - 1].timestamp;
     const holdingMs = Math.max(0, new Date(exitTime).getTime() - new Date(entryTime).getTime());
 
-    tradeResults.push({
-      marketId: market.id,
-      direction: decision.direction,
-      entryTime,
-      exitTime,
-      holdingMs,
-      pnl,
-      roi
-    });
+    tradeResults.push({ marketId: market.id, direction: decision.direction, entryTime, exitTime, holdingMs, pnl, roi });
   }
 
-  const summary = calculateBacktestMetrics(
-    tradeResults,
-    config.engine.startingBankroll,
-    bankroll,
-    equityCurve
-  );
+  const summary = calculateBacktestMetrics(tradeResults, config.engine.startingBankroll, bankroll, equityCurve);
+  const { train, test } = splitTrainTest(tradeResults);
+  const trainSummary = calculateBacktestMetrics(train, config.engine.startingBankroll, config.engine.startingBankroll + train.reduce((s, t) => s + t.pnl, 0), [config.engine.startingBankroll, config.engine.startingBankroll + train.reduce((s, t) => s + t.pnl, 0)]);
+  const testStart = config.engine.startingBankroll + train.reduce((s, t) => s + t.pnl, 0);
+  const testSummary = calculateBacktestMetrics(test, testStart, testStart + test.reduce((s, t) => s + t.pnl, 0), [testStart, testStart + test.reduce((s, t) => s + t.pnl, 0)]);
+
+  const overfitWarning = trainSummary.roi > 0.1 && testSummary.roi < 0.02;
 
   const artifact = {
     mode: 'backtest',
@@ -88,9 +97,16 @@ export const runBacktest = (markets: Market[], trades: WalletTrade[], config: Ap
     scannedMarkets: scanned.length,
     decisionCount: decisions.length,
     tradeResults,
-    summary
+    summary,
+    trainSummary,
+    testSummary,
+    overfitWarning
   };
 
   writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'backtest_summary.json'), artifact);
+  writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'backtest_train_summary.json'), trainSummary);
+  writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'backtest_test_summary.json'), testSummary);
+  writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'guardrail_rejections.json'), rejections);
+
   return artifact;
 };

--- a/paper-trading-mvp/src/backtest/metrics.ts
+++ b/paper-trading-mvp/src/backtest/metrics.ts
@@ -1,0 +1,71 @@
+export interface BacktestTradeResult {
+  marketId: string;
+  direction: 'yes' | 'no';
+  entryTime: string;
+  exitTime: string;
+  holdingMs: number;
+  pnl: number;
+  roi: number;
+}
+
+export interface BacktestSummary {
+  totalTrades: number;
+  winRate: number;
+  realizedPnl: number;
+  roi: number;
+  maxDrawdown: number;
+  averageHoldingTimeHours: number;
+  profitFactor: number;
+  sharpeLike: number;
+  endingBankroll: number;
+}
+
+export const calculateMaxDrawdown = (equityCurve: number[]): number => {
+  if (equityCurve.length === 0) return 0;
+  let peak = equityCurve[0];
+  let maxDrawdown = 0;
+  for (const value of equityCurve) {
+    peak = Math.max(peak, value);
+    maxDrawdown = Math.max(maxDrawdown, peak - value);
+  }
+  return maxDrawdown;
+};
+
+export const calculateBacktestMetrics = (
+  trades: BacktestTradeResult[],
+  startingBankroll: number,
+  endingBankroll: number,
+  equityCurve: number[]
+): BacktestSummary => {
+  const totalTrades = trades.length;
+  const wins = trades.filter((t) => t.pnl > 0);
+  const losses = trades.filter((t) => t.pnl < 0);
+  const realizedPnl = endingBankroll - startingBankroll;
+  const roi = startingBankroll > 0 ? realizedPnl / startingBankroll : 0;
+  const winRate = totalTrades > 0 ? wins.length / totalTrades : 0;
+  const averageHoldingTimeHours =
+    totalTrades > 0 ? trades.reduce((sum, t) => sum + t.holdingMs, 0) / totalTrades / 3_600_000 : 0;
+
+  const grossProfit = wins.reduce((sum, t) => sum + t.pnl, 0);
+  const grossLoss = Math.abs(losses.reduce((sum, t) => sum + t.pnl, 0));
+  const profitFactor = grossLoss === 0 ? (grossProfit > 0 ? Number.POSITIVE_INFINITY : 0) : grossProfit / grossLoss;
+
+  const returns = trades.map((t) => t.roi);
+  const mean = returns.length ? returns.reduce((a, b) => a + b, 0) / returns.length : 0;
+  const variance =
+    returns.length > 1 ? returns.reduce((sum, r) => sum + (r - mean) ** 2, 0) / (returns.length - 1) : 0;
+  const std = Math.sqrt(variance);
+  const sharpeLike = std === 0 ? 0 : (mean / std) * Math.sqrt(Math.max(1, returns.length));
+
+  return {
+    totalTrades,
+    winRate,
+    realizedPnl,
+    roi,
+    maxDrawdown: calculateMaxDrawdown(equityCurve),
+    averageHoldingTimeHours,
+    profitFactor,
+    sharpeLike,
+    endingBankroll
+  };
+};

--- a/paper-trading-mvp/src/config/defaultConfig.ts
+++ b/paper-trading-mvp/src/config/defaultConfig.ts
@@ -17,6 +17,9 @@ export interface AppConfig {
   };
   walletIntel: {
     minTradesForTrust: number;
+    minTrades: number;
+    minRealizedPnl: number;
+    minConfidenceScore: number;
     topN: number;
   };
   strategy: {
@@ -42,6 +45,7 @@ export interface AppConfig {
   polymarket: {
     apiBase: string;
     limit: number;
+    tradeHistoryEndpoint?: string;
   };
 }
 
@@ -62,6 +66,9 @@ export const defaultConfig: AppConfig = {
   },
   walletIntel: {
     minTradesForTrust: 8,
+    minTrades: 2,
+    minRealizedPnl: -1000000,
+    minConfidenceScore: 0.2,
     topN: 5
   },
   strategy: {

--- a/paper-trading-mvp/src/config/defaultConfig.ts
+++ b/paper-trading-mvp/src/config/defaultConfig.ts
@@ -55,6 +55,13 @@ export interface AppConfig {
     limit: number;
     tradeHistoryEndpoint?: string;
   };
+  llm: {
+    enabled: boolean;
+    provider: "none" | "anthropic" | "openai";
+    model: string;
+    maxMarketsPerRun: number;
+    timeoutMs: number;
+  };
 }
 
 export const defaultConfig: AppConfig = {
@@ -110,6 +117,13 @@ export const defaultConfig: AppConfig = {
   polymarket: {
     apiBase: 'https://gamma-api.polymarket.com',
     limit: 200
+  },
+  llm: {
+    enabled: false,
+    provider: 'none',
+    model: 'gpt-4o-mini',
+    maxMarketsPerRun: 5,
+    timeoutMs: 7000
   }
 };
 
@@ -124,5 +138,6 @@ export const mergeConfig = (base: AppConfig, override: Partial<AppConfig>): AppC
   exits: { ...base.exits, ...(override.exits ?? {}) },
   engine: { ...base.engine, ...(override.engine ?? {}) },
   guardrails: { ...base.guardrails, ...(override.guardrails ?? {}) },
-  polymarket: { ...base.polymarket, ...(override.polymarket ?? {}) }
+  polymarket: { ...base.polymarket, ...(override.polymarket ?? {}) },
+  llm: { ...base.llm, ...(override.llm ?? {}) }
 });

--- a/paper-trading-mvp/src/config/defaultConfig.ts
+++ b/paper-trading-mvp/src/config/defaultConfig.ts
@@ -1,11 +1,51 @@
-export const defaultConfig = {
+export interface AppConfig {
+  scanner: {
+    minLiquidity: number;
+    maxSpread: number;
+    minHoursToResolution: number;
+    maxHoursToResolution: number;
+    categoryAllowList: string[];
+    categoryBlockList: string[];
+    minEstimatedEdge: number;
+  };
+  research: {
+    minConfidence: number;
+    passEdge: number;
+  };
+  walletIntel: {
+    minTradesForTrust: number;
+    topN: number;
+  };
+  strategy: {
+    fullPositionExposure: number;
+    halfPositionExposure: number;
+  };
+  risk: {
+    cappedKellyFraction: number;
+    maxPositionSize: number;
+    maxDailyLoss: number;
+    maxOpenPositions: number;
+  };
+  exits: {
+    targetRoi: number;
+    stopRoi: number;
+    staleThesisHours: number;
+    maxHoldingHours: number;
+  };
+  engine: {
+    startingBankroll: number;
+    artifactsDir: string;
+  };
+}
+
+export const defaultConfig: AppConfig = {
   scanner: {
     minLiquidity: 20000,
     maxSpread: 0.06,
     minHoursToResolution: 4,
     maxHoursToResolution: 30000,
-    categoryAllowList: ['politics', 'sports', 'crypto', 'macro'] as const,
-    categoryBlockList: ['other'] as const,
+    categoryAllowList: ['politics', 'sports', 'crypto', 'macro'],
+    categoryBlockList: ['other'],
     minEstimatedEdge: 0.005
   },
   research: {
@@ -33,8 +73,19 @@ export const defaultConfig = {
     maxHoldingHours: 36
   },
   engine: {
-    startingBankroll: 10000
+    startingBankroll: 10000,
+    artifactsDir: 'artifacts'
   }
 };
 
-export type AppConfig = typeof defaultConfig;
+export const mergeConfig = (base: AppConfig, override: Partial<AppConfig>): AppConfig => ({
+  ...base,
+  ...override,
+  scanner: { ...base.scanner, ...(override.scanner ?? {}) },
+  research: { ...base.research, ...(override.research ?? {}) },
+  walletIntel: { ...base.walletIntel, ...(override.walletIntel ?? {}) },
+  strategy: { ...base.strategy, ...(override.strategy ?? {}) },
+  risk: { ...base.risk, ...(override.risk ?? {}) },
+  exits: { ...base.exits, ...(override.exits ?? {}) },
+  engine: { ...base.engine, ...(override.engine ?? {}) }
+});

--- a/paper-trading-mvp/src/config/defaultConfig.ts
+++ b/paper-trading-mvp/src/config/defaultConfig.ts
@@ -1,4 +1,7 @@
+export type MarketSourceType = 'sample' | 'polymarket';
+
 export interface AppConfig {
+  marketSource: MarketSourceType;
   scanner: {
     minLiquidity: number;
     maxSpread: number;
@@ -36,9 +39,14 @@ export interface AppConfig {
     startingBankroll: number;
     artifactsDir: string;
   };
+  polymarket: {
+    apiBase: string;
+    limit: number;
+  };
 }
 
 export const defaultConfig: AppConfig = {
+  marketSource: 'sample',
   scanner: {
     minLiquidity: 20000,
     maxSpread: 0.06,
@@ -75,6 +83,10 @@ export const defaultConfig: AppConfig = {
   engine: {
     startingBankroll: 10000,
     artifactsDir: 'artifacts'
+  },
+  polymarket: {
+    apiBase: 'https://gamma-api.polymarket.com',
+    limit: 200
   }
 };
 
@@ -87,5 +99,6 @@ export const mergeConfig = (base: AppConfig, override: Partial<AppConfig>): AppC
   strategy: { ...base.strategy, ...(override.strategy ?? {}) },
   risk: { ...base.risk, ...(override.risk ?? {}) },
   exits: { ...base.exits, ...(override.exits ?? {}) },
-  engine: { ...base.engine, ...(override.engine ?? {}) }
+  engine: { ...base.engine, ...(override.engine ?? {}) },
+  polymarket: { ...base.polymarket, ...(override.polymarket ?? {}) }
 });

--- a/paper-trading-mvp/src/config/defaultConfig.ts
+++ b/paper-trading-mvp/src/config/defaultConfig.ts
@@ -42,6 +42,14 @@ export interface AppConfig {
     startingBankroll: number;
     artifactsDir: string;
   };
+  guardrails: {
+    minLiquidity: number;
+    maxSpread: number;
+    minEdgeAfterSpread: number;
+    minWalletSampleSize: number;
+    minHoursToResolution: number;
+    maxPriceStaleMinutes: number;
+  };
   polymarket: {
     apiBase: string;
     limit: number;
@@ -91,6 +99,14 @@ export const defaultConfig: AppConfig = {
     startingBankroll: 10000,
     artifactsDir: 'artifacts'
   },
+  guardrails: {
+    minLiquidity: 20000,
+    maxSpread: 0.06,
+    minEdgeAfterSpread: 0.005,
+    minWalletSampleSize: 2,
+    minHoursToResolution: 4,
+    maxPriceStaleMinutes: 180
+  },
   polymarket: {
     apiBase: 'https://gamma-api.polymarket.com',
     limit: 200
@@ -107,5 +123,6 @@ export const mergeConfig = (base: AppConfig, override: Partial<AppConfig>): AppC
   risk: { ...base.risk, ...(override.risk ?? {}) },
   exits: { ...base.exits, ...(override.exits ?? {}) },
   engine: { ...base.engine, ...(override.engine ?? {}) },
+  guardrails: { ...base.guardrails, ...(override.guardrails ?? {}) },
   polymarket: { ...base.polymarket, ...(override.polymarket ?? {}) }
 });

--- a/paper-trading-mvp/src/config/defaultConfig.ts
+++ b/paper-trading-mvp/src/config/defaultConfig.ts
@@ -1,0 +1,40 @@
+export const defaultConfig = {
+  scanner: {
+    minLiquidity: 20000,
+    maxSpread: 0.06,
+    minHoursToResolution: 4,
+    maxHoursToResolution: 30000,
+    categoryAllowList: ['politics', 'sports', 'crypto', 'macro'] as const,
+    categoryBlockList: ['other'] as const,
+    minEstimatedEdge: 0.005
+  },
+  research: {
+    minConfidence: 0.5,
+    passEdge: 0.01
+  },
+  walletIntel: {
+    minTradesForTrust: 8,
+    topN: 5
+  },
+  strategy: {
+    fullPositionExposure: 1,
+    halfPositionExposure: 0.5
+  },
+  risk: {
+    cappedKellyFraction: 0.5,
+    maxPositionSize: 400,
+    maxDailyLoss: 800,
+    maxOpenPositions: 8
+  },
+  exits: {
+    targetRoi: 0.25,
+    stopRoi: -0.12,
+    staleThesisHours: 24,
+    maxHoldingHours: 36
+  },
+  engine: {
+    startingBankroll: 10000
+  }
+};
+
+export type AppConfig = typeof defaultConfig;

--- a/paper-trading-mvp/src/data/marketSource.ts
+++ b/paper-trading-mvp/src/data/marketSource.ts
@@ -1,0 +1,8 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Market } from '../types/market';
+
+export const loadMarkets = (): Market[] => {
+  const filePath = path.resolve(process.cwd(), 'data', 'sample_markets.json');
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Market[];
+};

--- a/paper-trading-mvp/src/data/marketSource.ts
+++ b/paper-trading-mvp/src/data/marketSource.ts
@@ -1,8 +1,9 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { Market } from '../types/market';
+import { readJson } from '../utils/io';
+import { validateMarkets } from '../utils/validation';
 
-export const loadMarkets = (): Market[] => {
-  const filePath = path.resolve(process.cwd(), 'data', 'sample_markets.json');
-  return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Market[];
+export const loadMarkets = (customPath?: string): Market[] => {
+  const filePath = customPath ? path.resolve(customPath) : path.resolve(process.cwd(), 'data', 'sample_markets.json');
+  return validateMarkets(readJson(filePath));
 };

--- a/paper-trading-mvp/src/data/polymarketMarketSource.ts
+++ b/paper-trading-mvp/src/data/polymarketMarketSource.ts
@@ -1,0 +1,100 @@
+import { AppConfig } from '../config/defaultConfig';
+import { Market } from '../types/market';
+
+interface RawPolymarketMarket {
+  id?: string;
+  question?: string;
+  active?: boolean;
+  closed?: boolean;
+  endDate?: string;
+  liquidity?: number | string;
+  volume?: number | string;
+  bestBid?: number | string;
+  bestAsk?: number | string;
+  outcomePrices?: string | number[];
+  category?: string;
+}
+
+const parseNumber = (value: unknown, fallback = 0): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+};
+
+const parseOutcomePrices = (value: unknown): number[] => {
+  if (Array.isArray(value)) return value.map((v) => parseNumber(v, 0));
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      return Array.isArray(parsed) ? parsed.map((v) => parseNumber(v, 0)) : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+};
+
+const normalizeMarket = (raw: RawPolymarketMarket): Market | null => {
+  if (!raw.id || !raw.question) return null;
+  if (raw.closed || raw.active === false) return null;
+
+  const prices = parseOutcomePrices(raw.outcomePrices);
+  const currentPrice = prices.length > 0 ? Math.min(0.99, Math.max(0.01, prices[0])) : 0.5;
+
+  const bestBid = parseNumber(raw.bestBid, currentPrice - 0.02);
+  const bestAsk = parseNumber(raw.bestAsk, currentPrice + 0.02);
+  const spread = Math.max(0, Math.min(0.5, bestAsk - bestBid));
+
+  return {
+    id: String(raw.id),
+    question: String(raw.question),
+    category: (raw.category ?? 'other') as Market['category'],
+    currentPrice,
+    spread,
+    liquidity: parseNumber(raw.liquidity, 0),
+    volume24h: parseNumber(raw.volume, 0),
+    resolutionAt: raw.endDate && !Number.isNaN(new Date(raw.endDate).getTime()) ? raw.endDate : new Date(Date.now() + 7 * 86400000).toISOString()
+  };
+};
+
+export const loadPolymarketMarkets = async (
+  config: AppConfig,
+  fetchImpl: typeof fetch = fetch
+): Promise<Market[]> => {
+  const endpoint = `${config.polymarket.apiBase}/markets?active=true&closed=false&limit=${config.polymarket.limit}`;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(endpoint);
+  } catch (error) {
+    throw new Error(`Polymarket market fetch failed (network): ${(error as Error).message}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Polymarket market fetch failed with status ${response.status}.`);
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new Error(`Polymarket market fetch returned invalid JSON: ${(error as Error).message}`);
+  }
+
+  if (!Array.isArray(payload)) {
+    throw new Error('Polymarket response malformed: expected an array of markets.');
+  }
+
+  const normalized = payload
+    .map((item) => normalizeMarket(item as RawPolymarketMarket))
+    .filter((m): m is Market => m !== null);
+
+  if (normalized.length === 0) {
+    throw new Error('Polymarket response contained no active markets after normalization.');
+  }
+
+  return normalized;
+};

--- a/paper-trading-mvp/src/data/polymarketTradeHistorySource.ts
+++ b/paper-trading-mvp/src/data/polymarketTradeHistorySource.ts
@@ -5,7 +5,7 @@ import { WalletTrade } from '../types/wallet';
 import { readJson } from '../utils/io';
 import { validateWalletTrades } from '../utils/validation';
 
-export type TradeSourceType = 'sample' | 'csv' | 'json';
+export type TradeSourceType = 'sample' | 'csv' | 'json' | 'fills';
 
 const parseCsvLine = (line: string): string[] => {
   const cells: string[] = [];
@@ -105,7 +105,7 @@ export const loadTradeHistory = (
     return validateWalletTrades(readJson(resolved));
   }
 
-  if (source === 'csv') {
+  if (source === 'csv' || source === 'fills') {
     const raw = fs.readFileSync(resolved, 'utf-8');
     return parseCsvTrades(raw);
   }

--- a/paper-trading-mvp/src/data/polymarketTradeHistorySource.ts
+++ b/paper-trading-mvp/src/data/polymarketTradeHistorySource.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { AppConfig } from '../config/defaultConfig';
+import { WalletTrade } from '../types/wallet';
+import { readJson } from '../utils/io';
+import { validateWalletTrades } from '../utils/validation';
+
+export type TradeSourceType = 'sample' | 'csv' | 'json';
+
+const parseCsvLine = (line: string): string[] => {
+  const cells: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (char === ',' && !inQuotes) {
+      cells.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  cells.push(current.trim());
+  return cells;
+};
+
+const parseCsvTrades = (csv: string): WalletTrade[] => {
+  const lines = csv.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  if (lines.length < 2) throw new Error('CSV trade file must contain a header and at least one row.');
+
+  const headers = parseCsvLine(lines[0]);
+  const required = ['wallet', 'marketId', 'category', 'stake', 'payout', 'timestamp'];
+  for (const field of required) {
+    if (!headers.includes(field)) throw new Error(`CSV trade file missing required header '${field}'.`);
+  }
+
+  const rows = lines.slice(1).map((line, idx) => {
+    const values = parseCsvLine(line);
+    if (values.length !== headers.length) {
+      throw new Error(`Malformed CSV row ${idx + 2}: column count mismatch.`);
+    }
+    const row: Record<string, string> = {};
+    headers.forEach((header, i) => {
+      row[header] = values[i] ?? '';
+    });
+    return row;
+  });
+
+  return validateWalletTrades(
+    rows.map((row) => ({
+      wallet: row.wallet,
+      marketId: row.marketId,
+      category: row.category,
+      stake: Number(row.stake),
+      payout: Number(row.payout),
+      timestamp: row.timestamp
+    }))
+  );
+};
+
+export const loadPolymarketTradeHistoryFromApi = async (
+  config: AppConfig,
+  fetchImpl: typeof fetch = fetch
+): Promise<WalletTrade[]> => {
+  if (!config.polymarket.tradeHistoryEndpoint) {
+    throw new Error('No tradeHistoryEndpoint configured for Polymarket read-only API adapter.');
+  }
+
+  const endpoint = config.polymarket.tradeHistoryEndpoint;
+  let response: Response;
+  try {
+    response = await fetchImpl(endpoint);
+  } catch (error) {
+    throw new Error(`Trade history fetch failed (network): ${(error as Error).message}`);
+  }
+
+  if (!response.ok) throw new Error(`Trade history fetch failed with status ${response.status}.`);
+
+  const payload = await response.json();
+  if (!Array.isArray(payload)) throw new Error('Trade history API response malformed: expected array.');
+  return validateWalletTrades(payload);
+};
+
+export const loadTradeHistory = (
+  source: TradeSourceType,
+  filePath: string | undefined,
+  config: AppConfig
+): WalletTrade[] => {
+  if (source === 'sample') {
+    const samplePath = filePath ? path.resolve(filePath) : path.resolve(process.cwd(), 'data', 'sample_trades.json');
+    return validateWalletTrades(readJson(samplePath));
+  }
+
+  if (!filePath) throw new Error(`--trade-file is required when --trade-source is '${source}'.`);
+
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) throw new Error(`Trade file does not exist: ${resolved}`);
+
+  if (source === 'json') {
+    return validateWalletTrades(readJson(resolved));
+  }
+
+  if (source === 'csv') {
+    const raw = fs.readFileSync(resolved, 'utf-8');
+    return parseCsvTrades(raw);
+  }
+
+  throw new Error(`Unsupported trade source '${source}'.`);
+};
+
+export const __private__ = {
+  parseCsvLine,
+  parseCsvTrades
+};

--- a/paper-trading-mvp/src/data/tradeHistorySource.ts
+++ b/paper-trading-mvp/src/data/tradeHistorySource.ts
@@ -1,9 +1,6 @@
-import path from 'node:path';
+import { AppConfig, defaultConfig } from '../config/defaultConfig';
 import { WalletTrade } from '../types/wallet';
-import { readJson } from '../utils/io';
-import { validateWalletTrades } from '../utils/validation';
+import { loadTradeHistory } from './polymarketTradeHistorySource';
 
-export const loadWalletTrades = (customPath?: string): WalletTrade[] => {
-  const filePath = customPath ? path.resolve(customPath) : path.resolve(process.cwd(), 'data', 'sample_trades.json');
-  return validateWalletTrades(readJson(filePath));
-};
+export const loadWalletTrades = (customPath?: string, config: AppConfig = defaultConfig): WalletTrade[] =>
+  loadTradeHistory(customPath ? 'json' : 'sample', customPath, config);

--- a/paper-trading-mvp/src/data/tradeHistorySource.ts
+++ b/paper-trading-mvp/src/data/tradeHistorySource.ts
@@ -1,8 +1,9 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { WalletTrade } from '../types/wallet';
+import { readJson } from '../utils/io';
+import { validateWalletTrades } from '../utils/validation';
 
-export const loadWalletTrades = (): WalletTrade[] => {
-  const filePath = path.resolve(process.cwd(), 'data', 'sample_trades.json');
-  return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as WalletTrade[];
+export const loadWalletTrades = (customPath?: string): WalletTrade[] => {
+  const filePath = customPath ? path.resolve(customPath) : path.resolve(process.cwd(), 'data', 'sample_trades.json');
+  return validateWalletTrades(readJson(filePath));
 };

--- a/paper-trading-mvp/src/data/tradeHistorySource.ts
+++ b/paper-trading-mvp/src/data/tradeHistorySource.ts
@@ -1,0 +1,8 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { WalletTrade } from '../types/wallet';
+
+export const loadWalletTrades = (): WalletTrade[] => {
+  const filePath = path.resolve(process.cwd(), 'data', 'sample_trades.json');
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as WalletTrade[];
+};

--- a/paper-trading-mvp/src/import/importer.ts
+++ b/paper-trading-mvp/src/import/importer.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Market } from '../types/market';
+import { WalletTrade } from '../types/wallet';
+import { writeJson } from '../utils/io';
+import { validateMarkets, validateWalletTrades } from '../utils/validation';
+
+export type ImportInputType = 'markets' | 'trades' | 'fills';
+
+const parseNumber = (value: unknown, fallback = 0): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+};
+
+const parseJsonFile = (inputPath: string): unknown[] => {
+  const raw = JSON.parse(fs.readFileSync(inputPath, 'utf-8')) as unknown;
+  if (!Array.isArray(raw)) throw new Error('Import input JSON must be an array of objects.');
+  return raw;
+};
+
+const parseCsvLine = (line: string): string[] => {
+  const out: string[] = [];
+  let cell = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const c = line[i];
+    if (c === '"') {
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (c === ',' && !inQuotes) {
+      out.push(cell.trim());
+      cell = '';
+      continue;
+    }
+    cell += c;
+  }
+  out.push(cell.trim());
+  return out;
+};
+
+const parseCsvFile = (inputPath: string): Record<string, string>[] => {
+  const lines = fs.readFileSync(inputPath, 'utf-8').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  if (lines.length < 2) throw new Error('CSV input must include a header and at least one data row.');
+  const headers = parseCsvLine(lines[0]);
+  return lines.slice(1).map((line, idx) => {
+    const cells = parseCsvLine(line);
+    if (cells.length !== headers.length) {
+      throw new Error(`Malformed CSV row ${idx + 2}: expected ${headers.length} columns, got ${cells.length}.`);
+    }
+    return headers.reduce<Record<string, string>>((acc, h, i) => {
+      acc[h] = cells[i] ?? '';
+      return acc;
+    }, {});
+  });
+};
+
+const normalizeCategory = (value: unknown): Market['category'] => {
+  const raw = String(value ?? 'other').toLowerCase();
+  if (raw.includes('politic')) return 'politics';
+  if (raw.includes('sport')) return 'sports';
+  if (raw.includes('crypto') || raw.includes('bitcoin') || raw.includes('eth')) return 'crypto';
+  if (raw.includes('macro') || raw.includes('econom')) return 'macro';
+  return 'other';
+};
+
+const asMarkets = (rows: unknown[]): Market[] => {
+  const mapped = rows.map((raw) => {
+    const row = raw as Record<string, unknown>;
+    const bid = parseNumber(row.bestBid ?? row.best_bid, 0.48);
+    const ask = parseNumber(row.bestAsk ?? row.best_ask, 0.52);
+    const currentPrice = parseNumber(
+      row.currentPrice ?? row.current_price ?? row.price ?? row.lastPrice ?? row.last_price,
+      parseNumber(row.yes_price, 0.5)
+    );
+    const spread = parseNumber(row.spread, Math.max(0, ask - bid));
+    return {
+      id: String(row.id ?? row.marketId ?? row.market_id ?? row.condition_id ?? ''),
+      question: String(row.question ?? row.title ?? row.market_question ?? ''),
+      category: normalizeCategory(row.category),
+      currentPrice: Math.min(0.99, Math.max(0.01, currentPrice || 0.5)),
+      spread: Math.max(0, Math.min(0.5, spread)),
+      liquidity: parseNumber(row.liquidity ?? row.liquidityNum ?? row.totalLiquidity ?? row.volume ?? row.volumeNum, 1),
+      volume24h: parseNumber(row.volume24h ?? row.volume_24h ?? row.volume ?? row.usd_volume, 0),
+      resolutionAt: String(row.resolutionAt ?? row.endDate ?? row.closeTime ?? row.closedTime ?? row.resolution_time ?? new Date().toISOString()),
+      lastPriceUpdatedAt: String(row.lastPriceUpdatedAt ?? row.updatedAt ?? row.last_updated_at ?? new Date().toISOString())
+    } satisfies Market;
+  });
+  return validateMarkets(mapped);
+};
+
+const asTrades = (rows: unknown[]): WalletTrade[] => {
+  const mapped = rows.map((raw) => {
+    const row = raw as Record<string, unknown>;
+    const stake = parseNumber(row.stake ?? row.usd_amount ?? row.notional ?? row.amount ?? row.size, 0);
+    const price = parseNumber(row.price ?? row.yes_price ?? row.avg_price, 0.5);
+    const payout = parseNumber(row.payout, stake * (price > 0 ? 1 / Math.max(0.01, price) : 1));
+
+    return {
+      wallet: String(row.wallet ?? row.maker ?? row.taker ?? row.account ?? 'unknown_wallet'),
+      marketId: String(row.marketId ?? row.market_id ?? row.id ?? row.condition_id ?? ''),
+      category: normalizeCategory(row.category),
+      stake,
+      payout,
+      timestamp: String(row.timestamp ?? row.createdAt ?? row.created_at ?? row.time ?? new Date().toISOString())
+    } satisfies WalletTrade;
+  });
+
+  return validateWalletTrades(mapped);
+};
+
+export const importAndNormalize = (inputPath: string, inputType: ImportInputType, outputPath: string) => {
+  const resolvedInput = path.resolve(inputPath);
+  if (!fs.existsSync(resolvedInput)) throw new Error(`Import input does not exist: ${resolvedInput}`);
+
+  const rows = resolvedInput.endsWith('.csv') ? parseCsvFile(resolvedInput) : parseJsonFile(resolvedInput);
+
+  if (inputType === 'markets') {
+    const markets = asMarkets(rows);
+    writeJson(path.resolve(outputPath), markets);
+    return { count: markets.length, outputType: 'markets' as const };
+  }
+
+  const trades = asTrades(rows);
+  writeJson(path.resolve(outputPath), trades);
+  return { count: trades.length, outputType: 'trades' as const };
+};

--- a/paper-trading-mvp/src/index.ts
+++ b/paper-trading-mvp/src/index.ts
@@ -60,7 +60,7 @@ const main = async (): Promise<void> => {
     const research = runResearch(config);
     const wallets = rankWallets(tradeHistory, config);
     const decisions = buildStrategyDecisions(scanned, research, wallets, config);
-    const { ledger, metrics } = runPaperEngine(decisions, scanned, config);
+    const { ledger, metrics } = runPaperEngine(decisions, scanned, wallets, config);
 
     const summary = {
       mode,

--- a/paper-trading-mvp/src/index.ts
+++ b/paper-trading-mvp/src/index.ts
@@ -10,6 +10,7 @@ import { loadMarkets } from './data/marketSource';
 import { loadPolymarketMarkets } from './data/polymarketMarketSource';
 import { TradeSourceType, loadTradeHistory } from './data/polymarketTradeHistorySource';
 import { runPaperEngine } from './paper/engine';
+import { buildReportArtifacts } from './reporting/reportBuilder';
 import { parseCliArgs } from './utils/cli';
 import { readJson, writeJson } from './utils/io';
 
@@ -50,6 +51,8 @@ const main = async (): Promise<void> => {
       const result = runBacktest(markets, tradeHistory, config);
       console.log('--- Backtest Summary ---');
       console.log(result.summary);
+      const report = buildReportArtifacts({ mode: 'backtest', artifactsDir: config.engine.artifactsDir });
+      console.log(`Report generated: ${report.mdPath} and ${report.htmlPath}`);
       console.log(`Artifacts written to ${path.resolve(process.cwd(), config.engine.artifactsDir)}`);
       return;
     }
@@ -97,6 +100,8 @@ const main = async (): Promise<void> => {
 
     console.log('\n--- Metrics ---');
     console.log(summary);
+    const report = buildReportArtifacts({ mode: 'paper', artifactsDir: config.engine.artifactsDir });
+    console.log(`Report generated: ${report.mdPath} and ${report.htmlPath}`);
     console.log(`Artifacts written to ${path.resolve(process.cwd(), config.engine.artifactsDir)}`);
   } catch (error) {
     console.error(`Pipeline failed: ${(error as Error).message}`);

--- a/paper-trading-mvp/src/index.ts
+++ b/paper-trading-mvp/src/index.ts
@@ -14,6 +14,7 @@ import { analyzeDataQuality, persistDataQualityReport } from './validation/dataQ
 import { buildReportArtifacts } from './reporting/reportBuilder';
 import { parseCliArgs } from './utils/cli';
 import { readJson, writeJson } from './utils/io';
+import { importAndNormalize } from './import/importer';
 
 const loadConfig = (configPath?: string): AppConfig => {
   if (!configPath) return defaultConfig;
@@ -42,6 +43,27 @@ const main = async (): Promise<void> => {
 
     if (!Number.isFinite(config.engine.startingBankroll) || config.engine.startingBankroll <= 0) {
       throw new Error('startingBankroll must be a positive number.');
+    }
+
+
+    if (mode === 'import') {
+      if (!args.input || !args.inputType || !args.output) {
+        throw new Error("Import mode requires --input, --input-type, and --output.");
+      }
+      const imported = importAndNormalize(args.input, args.inputType, args.output);
+      const summary = {
+        mode: 'import',
+        input: args.input,
+        inputType: args.inputType,
+        output: args.output,
+        outputType: imported.outputType,
+        recordsImported: imported.count,
+        createdAt: new Date().toISOString()
+      };
+      writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'import_summary.json'), summary);
+      console.log('--- Import Summary ---');
+      console.log(summary);
+      return;
     }
 
     const tradeSource: TradeSourceType = args.tradeSource ?? 'sample';

--- a/paper-trading-mvp/src/index.ts
+++ b/paper-trading-mvp/src/index.ts
@@ -1,54 +1,75 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { runResearch } from './agents/research';
 import { runScanner } from './agents/scanner';
 import { buildStrategyDecisions } from './agents/strategy';
 import { rankWallets } from './agents/walletIntel';
-import { defaultConfig } from './config/defaultConfig';
+import { AppConfig, defaultConfig, mergeConfig } from './config/defaultConfig';
 import { loadMarkets } from './data/marketSource';
 import { loadWalletTrades } from './data/tradeHistorySource';
 import { runPaperEngine } from './paper/engine';
+import { parseCliArgs } from './utils/cli';
+import { readJson, writeJson } from './utils/io';
+
+const loadConfig = (configPath?: string): AppConfig => {
+  if (!configPath) return defaultConfig;
+  const override = readJson(path.resolve(configPath)) as Partial<AppConfig>;
+  return mergeConfig(defaultConfig, override);
+};
 
 const main = (): void => {
-  const config = defaultConfig;
+  try {
+    const args = parseCliArgs(process.argv.slice(2));
+    const baseConfig = loadConfig(args.configPath);
+    const config = args.bankroll
+      ? mergeConfig(baseConfig, { engine: { ...baseConfig.engine, startingBankroll: args.bankroll } })
+      : baseConfig;
 
-  const markets = loadMarkets();
-  const scanned = runScanner(markets, config);
-  const survived = scanned.filter((m) => m.scannerPass);
+    if (!Number.isFinite(config.engine.startingBankroll) || config.engine.startingBankroll <= 0) {
+      throw new Error('startingBankroll must be a positive number.');
+    }
 
-  const research = runResearch(config);
-  const wallets = rankWallets(loadWalletTrades(), config);
-  const decisions = buildStrategyDecisions(scanned, research, wallets, config);
-  const { ledger, metrics } = runPaperEngine(decisions, scanned, config);
+    const markets = loadMarkets(args.marketsPath);
+    const scanned = runScanner(markets, config);
+    const survived = scanned.filter((m) => m.scannerPass);
 
-  const summary = {
-    scanned_markets: scanned.length,
-    scanner_survivors: survived.length,
-    selected_candidates: decisions.filter((d) => d.direction !== 'none').length,
-    simulated_trades: ledger.trades.length,
-    final_bankroll: metrics.finalBankroll,
-    win_rate: metrics.winRate,
-    drawdown: metrics.maxDrawdown,
-    sharpe_like: metrics.sharpeLike
-  };
+    const research = runResearch(config);
+    const wallets = rankWallets(loadWalletTrades(args.tradesPath), config);
+    const decisions = buildStrategyDecisions(scanned, research, wallets, config);
+    const { ledger, metrics } = runPaperEngine(decisions, scanned, config);
 
-  const summaryPath = path.resolve(process.cwd(), 'data', 'run_summary.json');
-  fs.writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
+    const summary = {
+      scanned_markets: scanned.length,
+      scanner_survivors: survived.length,
+      selected_candidates: decisions.filter((d) => d.direction !== 'none').length,
+      simulated_trades: ledger.trades.length,
+      final_bankroll: metrics.finalBankroll,
+      win_rate: metrics.winRate,
+      drawdown: metrics.maxDrawdown,
+      sharpe_like: metrics.sharpeLike,
+      note: ledger.trades.length === 0 ? 'No surviving trades were executed.' : 'Simulation completed.'
+    };
 
-  console.log('--- Scanner Survivors ---');
-  console.table(survived.map((m) => ({ id: m.id, edge: m.estimatedEdge.toFixed(4), price: m.currentPrice })));
+    const summaryPath = path.resolve(process.cwd(), config.engine.artifactsDir, 'run_summary.json');
+    writeJson(summaryPath, summary);
 
-  console.log('\n--- Strategy Candidates ---');
-  console.table(decisions.map((d) => ({ market: d.marketId, direction: d.direction, rationale: d.rationale })));
+    console.log('--- Scanner Survivors ---');
+    console.table(survived.map((m) => ({ id: m.id, edge: m.estimatedEdge.toFixed(4), price: m.currentPrice })));
 
-  console.log('\n--- Simulated Trades ---');
-  console.table(
-    ledger.trades.map((t) => ({ market: t.marketId, pnl: t.pnl.toFixed(2), roi: t.roi.toFixed(4), exit: t.exitReason }))
-  );
+    console.log('\n--- Strategy Candidates ---');
+    console.table(decisions.map((d) => ({ market: d.marketId, direction: d.direction, rationale: d.rationale })));
 
-  console.log('\n--- Metrics ---');
-  console.log(summary);
-  console.log(`Ledger saved to ${path.resolve(process.cwd(), 'data', 'paper_ledger.json')}`);
+    console.log('\n--- Simulated Trades ---');
+    console.table(
+      ledger.trades.map((t) => ({ market: t.marketId, pnl: t.pnl.toFixed(2), roi: t.roi.toFixed(4), exit: t.exitReason }))
+    );
+
+    console.log('\n--- Metrics ---');
+    console.log(summary);
+    console.log(`Artifacts written to ${path.resolve(process.cwd(), config.engine.artifactsDir)}`);
+  } catch (error) {
+    console.error(`Pipeline failed: ${(error as Error).message}`);
+    process.exit(1);
+  }
 };
 
 main();

--- a/paper-trading-mvp/src/index.ts
+++ b/paper-trading-mvp/src/index.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { runResearch } from './agents/research';
+import { runScanner } from './agents/scanner';
+import { buildStrategyDecisions } from './agents/strategy';
+import { rankWallets } from './agents/walletIntel';
+import { defaultConfig } from './config/defaultConfig';
+import { loadMarkets } from './data/marketSource';
+import { loadWalletTrades } from './data/tradeHistorySource';
+import { runPaperEngine } from './paper/engine';
+
+const main = (): void => {
+  const config = defaultConfig;
+
+  const markets = loadMarkets();
+  const scanned = runScanner(markets, config);
+  const survived = scanned.filter((m) => m.scannerPass);
+
+  const research = runResearch(config);
+  const wallets = rankWallets(loadWalletTrades(), config);
+  const decisions = buildStrategyDecisions(scanned, research, wallets, config);
+  const { ledger, metrics } = runPaperEngine(decisions, scanned, config);
+
+  const summary = {
+    scanned_markets: scanned.length,
+    scanner_survivors: survived.length,
+    selected_candidates: decisions.filter((d) => d.direction !== 'none').length,
+    simulated_trades: ledger.trades.length,
+    final_bankroll: metrics.finalBankroll,
+    win_rate: metrics.winRate,
+    drawdown: metrics.maxDrawdown,
+    sharpe_like: metrics.sharpeLike
+  };
+
+  const summaryPath = path.resolve(process.cwd(), 'data', 'run_summary.json');
+  fs.writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
+
+  console.log('--- Scanner Survivors ---');
+  console.table(survived.map((m) => ({ id: m.id, edge: m.estimatedEdge.toFixed(4), price: m.currentPrice })));
+
+  console.log('\n--- Strategy Candidates ---');
+  console.table(decisions.map((d) => ({ market: d.marketId, direction: d.direction, rationale: d.rationale })));
+
+  console.log('\n--- Simulated Trades ---');
+  console.table(
+    ledger.trades.map((t) => ({ market: t.marketId, pnl: t.pnl.toFixed(2), roi: t.roi.toFixed(4), exit: t.exitReason }))
+  );
+
+  console.log('\n--- Metrics ---');
+  console.log(summary);
+  console.log(`Ledger saved to ${path.resolve(process.cwd(), 'data', 'paper_ledger.json')}`);
+};
+
+main();

--- a/paper-trading-mvp/src/index.ts
+++ b/paper-trading-mvp/src/index.ts
@@ -6,7 +6,7 @@ import { rankWallets } from './agents/walletIntel';
 import { AppConfig, defaultConfig, mergeConfig } from './config/defaultConfig';
 import { loadMarkets } from './data/marketSource';
 import { loadPolymarketMarkets } from './data/polymarketMarketSource';
-import { loadWalletTrades } from './data/tradeHistorySource';
+import { TradeSourceType, loadTradeHistory } from './data/polymarketTradeHistorySource';
 import { runPaperEngine } from './paper/engine';
 import { parseCliArgs } from './utils/cli';
 import { readJson, writeJson } from './utils/io';
@@ -40,17 +40,21 @@ const main = async (): Promise<void> => {
       throw new Error('startingBankroll must be a positive number.');
     }
 
+    const tradeSource: TradeSourceType = args.tradeSource ?? 'sample';
+
     const markets = await resolveMarkets(config, args.marketsPath);
     const scanned = runScanner(markets, config);
     const survived = scanned.filter((m) => m.scannerPass);
 
     const research = runResearch(config);
-    const wallets = rankWallets(loadWalletTrades(args.tradesPath), config);
+    const tradeHistory = loadTradeHistory(tradeSource, args.tradeFile, config);
+    const wallets = rankWallets(tradeHistory, config);
     const decisions = buildStrategyDecisions(scanned, research, wallets, config);
     const { ledger, metrics } = runPaperEngine(decisions, scanned, config);
 
     const summary = {
       source: config.marketSource,
+      trade_source: tradeSource,
       scanned_markets: scanned.length,
       scanner_survivors: survived.length,
       selected_candidates: decisions.filter((d) => d.direction !== 'none').length,
@@ -67,6 +71,9 @@ const main = async (): Promise<void> => {
 
     console.log('--- Scanner Survivors ---');
     console.table(survived.map((m) => ({ id: m.id, edge: m.estimatedEdge.toFixed(4), price: m.currentPrice })));
+
+    console.log('\n--- Wallet Rankings ---');
+    console.table(wallets.map((w) => ({ wallet: w.wallet, trades: w.totalTrades, pnl: w.realizedPnl.toFixed(2), confidence: w.confidenceScore.toFixed(2) })));
 
     console.log('\n--- Strategy Candidates ---');
     console.table(decisions.map((d) => ({ market: d.marketId, direction: d.direction, rationale: d.rationale })));

--- a/paper-trading-mvp/src/index.ts
+++ b/paper-trading-mvp/src/index.ts
@@ -10,6 +10,7 @@ import { loadMarkets } from './data/marketSource';
 import { loadPolymarketMarkets } from './data/polymarketMarketSource';
 import { TradeSourceType, loadTradeHistory } from './data/polymarketTradeHistorySource';
 import { runPaperEngine } from './paper/engine';
+import { analyzeDataQuality, persistDataQualityReport } from './validation/dataQuality';
 import { buildReportArtifacts } from './reporting/reportBuilder';
 import { parseCliArgs } from './utils/cli';
 import { readJson, writeJson } from './utils/io';
@@ -46,6 +47,12 @@ const main = async (): Promise<void> => {
     const tradeSource: TradeSourceType = args.tradeSource ?? 'sample';
     const markets = await resolveMarkets(config, args.marketsPath);
     const tradeHistory = loadTradeHistory(tradeSource, args.tradeFile, config);
+
+    const dataQuality = analyzeDataQuality(markets, tradeHistory);
+    persistDataQualityReport(dataQuality, config.engine.artifactsDir);
+    if (args.strictData === 'on' && dataQuality.criticalIssues.length > 0) {
+      throw new Error(`Strict data mode failed: ${dataQuality.criticalIssues.join(';')}`);
+    }
 
     if (mode === 'backtest') {
       const result = runBacktest(markets, tradeHistory, config);

--- a/paper-trading-mvp/src/index.ts
+++ b/paper-trading-mvp/src/index.ts
@@ -5,6 +5,7 @@ import { buildStrategyDecisions } from './agents/strategy';
 import { rankWallets } from './agents/walletIntel';
 import { AppConfig, defaultConfig, mergeConfig } from './config/defaultConfig';
 import { loadMarkets } from './data/marketSource';
+import { loadPolymarketMarkets } from './data/polymarketMarketSource';
 import { loadWalletTrades } from './data/tradeHistorySource';
 import { runPaperEngine } from './paper/engine';
 import { parseCliArgs } from './utils/cli';
@@ -16,19 +17,30 @@ const loadConfig = (configPath?: string): AppConfig => {
   return mergeConfig(defaultConfig, override);
 };
 
-const main = (): void => {
+const resolveMarkets = async (config: AppConfig, marketsPath?: string) => {
+  if (config.marketSource === 'sample') return loadMarkets(marketsPath);
+  if (config.marketSource === 'polymarket') return loadPolymarketMarkets(config);
+  throw new Error(`Unsupported source '${String(config.marketSource)}'.`);
+};
+
+const main = async (): Promise<void> => {
   try {
     const args = parseCliArgs(process.argv.slice(2));
     const baseConfig = loadConfig(args.configPath);
-    const config = args.bankroll
+
+    let config = args.bankroll
       ? mergeConfig(baseConfig, { engine: { ...baseConfig.engine, startingBankroll: args.bankroll } })
       : baseConfig;
+
+    if (args.source) {
+      config = mergeConfig(config, { marketSource: args.source });
+    }
 
     if (!Number.isFinite(config.engine.startingBankroll) || config.engine.startingBankroll <= 0) {
       throw new Error('startingBankroll must be a positive number.');
     }
 
-    const markets = loadMarkets(args.marketsPath);
+    const markets = await resolveMarkets(config, args.marketsPath);
     const scanned = runScanner(markets, config);
     const survived = scanned.filter((m) => m.scannerPass);
 
@@ -38,6 +50,7 @@ const main = (): void => {
     const { ledger, metrics } = runPaperEngine(decisions, scanned, config);
 
     const summary = {
+      source: config.marketSource,
       scanned_markets: scanned.length,
       scanner_survivors: survived.length,
       selected_candidates: decisions.filter((d) => d.direction !== 'none').length,
@@ -72,4 +85,4 @@ const main = (): void => {
   }
 };
 
-main();
+void main();

--- a/paper-trading-mvp/src/index.ts
+++ b/paper-trading-mvp/src/index.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { runBacktest } from './backtest/engine';
 import { runResearch } from './agents/research';
 import { runScanner } from './agents/scanner';
 import { buildStrategyDecisions } from './agents/strategy';
@@ -26,6 +27,7 @@ const resolveMarkets = async (config: AppConfig, marketsPath?: string) => {
 const main = async (): Promise<void> => {
   try {
     const args = parseCliArgs(process.argv.slice(2));
+    const mode = args.mode ?? 'paper';
     const baseConfig = loadConfig(args.configPath);
 
     let config = args.bankroll
@@ -41,18 +43,27 @@ const main = async (): Promise<void> => {
     }
 
     const tradeSource: TradeSourceType = args.tradeSource ?? 'sample';
-
     const markets = await resolveMarkets(config, args.marketsPath);
+    const tradeHistory = loadTradeHistory(tradeSource, args.tradeFile, config);
+
+    if (mode === 'backtest') {
+      const result = runBacktest(markets, tradeHistory, config);
+      console.log('--- Backtest Summary ---');
+      console.log(result.summary);
+      console.log(`Artifacts written to ${path.resolve(process.cwd(), config.engine.artifactsDir)}`);
+      return;
+    }
+
     const scanned = runScanner(markets, config);
     const survived = scanned.filter((m) => m.scannerPass);
 
     const research = runResearch(config);
-    const tradeHistory = loadTradeHistory(tradeSource, args.tradeFile, config);
     const wallets = rankWallets(tradeHistory, config);
     const decisions = buildStrategyDecisions(scanned, research, wallets, config);
     const { ledger, metrics } = runPaperEngine(decisions, scanned, config);
 
     const summary = {
+      mode,
       source: config.marketSource,
       trade_source: tradeSource,
       scanned_markets: scanned.length,

--- a/paper-trading-mvp/src/index.ts
+++ b/paper-trading-mvp/src/index.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { runBacktest } from './backtest/engine';
+import { runLlmResearch } from './agents/llmResearch';
 import { runResearch } from './agents/research';
 import { runScanner } from './agents/scanner';
 import { buildStrategyDecisions } from './agents/strategy';
@@ -34,9 +35,8 @@ const main = async (): Promise<void> => {
       ? mergeConfig(baseConfig, { engine: { ...baseConfig.engine, startingBankroll: args.bankroll } })
       : baseConfig;
 
-    if (args.source) {
-      config = mergeConfig(config, { marketSource: args.source });
-    }
+    if (args.source) config = mergeConfig(config, { marketSource: args.source });
+    if (args.llm) config = mergeConfig(config, { llm: { ...config.llm, enabled: args.llm === 'on' } });
 
     if (!Number.isFinite(config.engine.startingBankroll) || config.engine.startingBankroll <= 0) {
       throw new Error('startingBankroll must be a positive number.');
@@ -58,14 +58,16 @@ const main = async (): Promise<void> => {
     const survived = scanned.filter((m) => m.scannerPass);
 
     const research = runResearch(config);
+    const llmReports = await runLlmResearch(survived, config);
     const wallets = rankWallets(tradeHistory, config);
-    const decisions = buildStrategyDecisions(scanned, research, wallets, config);
+    const decisions = buildStrategyDecisions(scanned, research, wallets, config, llmReports);
     const { ledger, metrics } = runPaperEngine(decisions, scanned, wallets, config);
 
     const summary = {
       mode,
       source: config.marketSource,
       trade_source: tradeSource,
+      llm_enabled: config.llm.enabled,
       scanned_markets: scanned.length,
       scanner_survivors: survived.length,
       selected_candidates: decisions.filter((d) => d.direction !== 'none').length,
@@ -77,8 +79,7 @@ const main = async (): Promise<void> => {
       note: ledger.trades.length === 0 ? 'No surviving trades were executed.' : 'Simulation completed.'
     };
 
-    const summaryPath = path.resolve(process.cwd(), config.engine.artifactsDir, 'run_summary.json');
-    writeJson(summaryPath, summary);
+    writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'run_summary.json'), summary);
 
     console.log('--- Scanner Survivors ---');
     console.table(survived.map((m) => ({ id: m.id, edge: m.estimatedEdge.toFixed(4), price: m.currentPrice })));

--- a/paper-trading-mvp/src/paper/engine.ts
+++ b/paper-trading-mvp/src/paper/engine.ts
@@ -13,6 +13,11 @@ export const runPaperEngine = (
 ) => {
   const ledger = initLedger(config.engine.startingBankroll);
 
+  if (decisions.length === 0) {
+    persistLedger(ledger, config.engine.artifactsDir);
+    return { ledger, metrics: computeMetrics(ledger, config.engine.startingBankroll) };
+  }
+
   for (const decision of decisions) {
     const market = scannedMarkets.find((m) => m.id === decision.marketId);
     if (!market) continue;
@@ -44,7 +49,7 @@ export const runPaperEngine = (
     recordClosedTrade(ledger, closed);
   }
 
-  persistLedger(ledger);
+  persistLedger(ledger, config.engine.artifactsDir);
   const metrics = computeMetrics(ledger, config.engine.startingBankroll);
   return { ledger, metrics };
 };

--- a/paper-trading-mvp/src/paper/engine.ts
+++ b/paper-trading-mvp/src/paper/engine.ts
@@ -1,21 +1,28 @@
+import path from 'node:path';
 import { simulateExit } from '../agents/exit';
 import { sizeDecision } from '../agents/risk';
 import { AppConfig } from '../config/defaultConfig';
 import { ScoredMarket } from '../types/market';
 import { StrategyDecision } from '../types/signal';
 import { SimulatedTrade } from '../types/trade';
+import { WalletScore } from '../types/wallet';
+import { writeJson } from '../utils/io';
+import { evaluateStrategyGuards } from '../validation/strategyGuards';
 import { computeMetrics, initLedger, persistLedger, recordClosedTrade } from './ledger';
 
 export const runPaperEngine = (
   decisions: StrategyDecision[],
   scannedMarkets: ScoredMarket[],
+  walletScores: WalletScore[],
   config: AppConfig
 ) => {
   const ledger = initLedger(config.engine.startingBankroll);
+  const rejections: Array<{ marketId: string; reasons: string[] }> = [];
 
   if (decisions.length === 0) {
     persistLedger(ledger, config.engine.artifactsDir);
-    return { ledger, metrics: computeMetrics(ledger, config.engine.startingBankroll) };
+    writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'guardrail_rejections.json'), rejections);
+    return { ledger, metrics: computeMetrics(ledger, config.engine.startingBankroll), rejections };
   }
 
   for (const decision of decisions) {
@@ -32,6 +39,12 @@ export const runPaperEngine = (
     );
 
     if (!sized.allowed || sized.sizeUsd <= 0 || (sized.direction !== 'yes' && sized.direction !== 'no')) continue;
+
+    const guard = evaluateStrategyGuards(market, decision, sized.sizeUsd, walletScores, config);
+    if (!guard.allowed) {
+      rejections.push({ marketId: market.id, reasons: guard.reasons });
+      continue;
+    }
 
     const trade: SimulatedTrade = {
       id: `sim_${market.id}_${ledger.trades.length + 1}`,
@@ -50,6 +63,7 @@ export const runPaperEngine = (
   }
 
   persistLedger(ledger, config.engine.artifactsDir);
+  writeJson(path.resolve(process.cwd(), config.engine.artifactsDir, 'guardrail_rejections.json'), rejections);
   const metrics = computeMetrics(ledger, config.engine.startingBankroll);
-  return { ledger, metrics };
+  return { ledger, metrics, rejections };
 };

--- a/paper-trading-mvp/src/paper/engine.ts
+++ b/paper-trading-mvp/src/paper/engine.ts
@@ -1,0 +1,50 @@
+import { simulateExit } from '../agents/exit';
+import { sizeDecision } from '../agents/risk';
+import { AppConfig } from '../config/defaultConfig';
+import { ScoredMarket } from '../types/market';
+import { StrategyDecision } from '../types/signal';
+import { SimulatedTrade } from '../types/trade';
+import { computeMetrics, initLedger, persistLedger, recordClosedTrade } from './ledger';
+
+export const runPaperEngine = (
+  decisions: StrategyDecision[],
+  scannedMarkets: ScoredMarket[],
+  config: AppConfig
+) => {
+  const ledger = initLedger(config.engine.startingBankroll);
+
+  for (const decision of decisions) {
+    const market = scannedMarkets.find((m) => m.id === decision.marketId);
+    if (!market) continue;
+
+    const sized = sizeDecision(
+      decision,
+      ledger.bankroll,
+      market.estimatedEdge,
+      ledger.bankroll - config.engine.startingBankroll,
+      0,
+      config
+    );
+
+    if (!sized.allowed || sized.sizeUsd <= 0 || (sized.direction !== 'yes' && sized.direction !== 'no')) continue;
+
+    const trade: SimulatedTrade = {
+      id: `sim_${market.id}_${ledger.trades.length + 1}`,
+      marketId: market.id,
+      question: market.question,
+      direction: sized.direction,
+      entryPrice: market.currentPrice,
+      positionSize: sized.sizeUsd,
+      quantity: sized.sizeUsd / Math.max(0.01, market.currentPrice),
+      openedAt: new Date().toISOString(),
+      maxHoldingMinutes: config.exits.maxHoldingHours * 60
+    };
+
+    const closed = simulateExit(trade, config);
+    recordClosedTrade(ledger, closed);
+  }
+
+  persistLedger(ledger);
+  const metrics = computeMetrics(ledger, config.engine.startingBankroll);
+  return { ledger, metrics };
+};

--- a/paper-trading-mvp/src/paper/ledger.ts
+++ b/paper-trading-mvp/src/paper/ledger.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { ClosedTrade, PaperMetrics } from '../types/trade';
+
+export interface LedgerState {
+  bankroll: number;
+  trades: ClosedTrade[];
+  equityCurve: number[];
+}
+
+export const initLedger = (startingBankroll: number): LedgerState => ({
+  bankroll: startingBankroll,
+  trades: [],
+  equityCurve: [startingBankroll]
+});
+
+export const recordClosedTrade = (ledger: LedgerState, trade: ClosedTrade): void => {
+  ledger.trades.push(trade);
+  ledger.bankroll += trade.pnl;
+  ledger.equityCurve.push(ledger.bankroll);
+};
+
+export const computeMetrics = (ledger: LedgerState, startingBankroll: number): PaperMetrics => {
+  const wins = ledger.trades.filter((t) => t.pnl > 0).length;
+  const totalPnl = ledger.bankroll - startingBankroll;
+  const winRate = ledger.trades.length ? wins / ledger.trades.length : 0;
+
+  let peak = ledger.equityCurve[0] ?? startingBankroll;
+  let maxDrawdown = 0;
+  for (const equity of ledger.equityCurve) {
+    peak = Math.max(peak, equity);
+    maxDrawdown = Math.max(maxDrawdown, peak - equity);
+  }
+
+  const returns = ledger.trades.map((t) => t.roi);
+  const meanReturn = returns.length ? returns.reduce((a, b) => a + b, 0) / returns.length : 0;
+  const variance =
+    returns.length > 1
+      ? returns.reduce((sum, r) => sum + (r - meanReturn) ** 2, 0) / (returns.length - 1)
+      : 0;
+  const std = Math.sqrt(variance);
+  const sharpeLike = std === 0 ? 0 : (meanReturn / std) * Math.sqrt(Math.max(1, returns.length));
+
+  return {
+    finalBankroll: ledger.bankroll,
+    totalPnl,
+    winRate,
+    maxDrawdown,
+    sharpeLike
+  };
+};
+
+export const persistLedger = (ledger: LedgerState): void => {
+  const outputPath = path.resolve(process.cwd(), 'data', 'paper_ledger.json');
+  fs.writeFileSync(outputPath, JSON.stringify(ledger, null, 2));
+};

--- a/paper-trading-mvp/src/paper/ledger.ts
+++ b/paper-trading-mvp/src/paper/ledger.ts
@@ -1,6 +1,6 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { ClosedTrade, PaperMetrics } from '../types/trade';
+import { writeJson } from '../utils/io';
 
 export interface LedgerState {
   bankroll: number;
@@ -50,7 +50,7 @@ export const computeMetrics = (ledger: LedgerState, startingBankroll: number): P
   };
 };
 
-export const persistLedger = (ledger: LedgerState): void => {
-  const outputPath = path.resolve(process.cwd(), 'data', 'paper_ledger.json');
-  fs.writeFileSync(outputPath, JSON.stringify(ledger, null, 2));
+export const persistLedger = (ledger: LedgerState, artifactsDir: string): void => {
+  const outputPath = path.resolve(process.cwd(), artifactsDir, 'paper_ledger.json');
+  writeJson(outputPath, ledger);
 };

--- a/paper-trading-mvp/src/reporting/reportBuilder.ts
+++ b/paper-trading-mvp/src/reporting/reportBuilder.ts
@@ -1,0 +1,147 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+interface BuildReportInput {
+  mode: 'paper' | 'backtest';
+  artifactsDir: string;
+}
+
+const safeRead = <T>(filePath: string, fallback: T): T => {
+  if (!fs.existsSync(filePath)) return fallback;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
+  } catch {
+    return fallback;
+  }
+};
+
+const toPct = (n: number): string => `${(n * 100).toFixed(2)}%`;
+
+export const buildReportArtifacts = ({ mode, artifactsDir }: BuildReportInput): { mdPath: string; htmlPath: string } => {
+  const dir = path.resolve(process.cwd(), artifactsDir);
+  const runSummary = safeRead<Record<string, unknown>>(path.join(dir, 'run_summary.json'), {});
+  const backtestSummary = safeRead<Record<string, unknown>>(path.join(dir, 'backtest_summary.json'), {});
+  const trainSummary = safeRead<Record<string, unknown>>(path.join(dir, 'backtest_train_summary.json'), {});
+  const testSummary = safeRead<Record<string, unknown>>(path.join(dir, 'backtest_test_summary.json'), {});
+  const guardRejections = safeRead<Array<{ marketId: string; reasons: string[] }>>(path.join(dir, 'guardrail_rejections.json'), []);
+  const llmResearch = safeRead<Array<Record<string, unknown>>>(path.join(dir, 'llm_research.json'), []);
+  const ledger = safeRead<{ trades?: Array<Record<string, unknown>>; bankroll?: number }>(path.join(dir, 'paper_ledger.json'), {});
+
+  const topAcceptedTrades =
+    mode === 'backtest'
+      ? (backtestSummary.tradeResults as Array<Record<string, unknown>> | undefined)?.slice(0, 5) ?? []
+      : (ledger.trades ?? []).slice(0, 5);
+
+  const finalBankroll =
+    mode === 'backtest'
+      ? Number((backtestSummary.summary as Record<string, unknown> | undefined)?.endingBankroll ?? 0)
+      : Number(runSummary.final_bankroll ?? ledger.bankroll ?? 0);
+
+  const roi =
+    mode === 'backtest'
+      ? Number((backtestSummary.summary as Record<string, unknown> | undefined)?.roi ?? 0)
+      : finalBankroll > 0 ? (finalBankroll - 10000) / 10000 : 0;
+
+  const winRate =
+    mode === 'backtest'
+      ? Number((backtestSummary.summary as Record<string, unknown> | undefined)?.winRate ?? 0)
+      : Number(runSummary.win_rate ?? 0);
+
+  const maxDrawdown =
+    mode === 'backtest'
+      ? Number((backtestSummary.summary as Record<string, unknown> | undefined)?.maxDrawdown ?? 0)
+      : Number(runSummary.drawdown ?? 0);
+
+  const profitFactor =
+    mode === 'backtest'
+      ? Number((backtestSummary.summary as Record<string, unknown> | undefined)?.profitFactor ?? 0)
+      : 0;
+
+  const sharpeLike =
+    mode === 'backtest'
+      ? Number((backtestSummary.summary as Record<string, unknown> | undefined)?.sharpeLike ?? 0)
+      : Number(runSummary.sharpe_like ?? 0);
+
+  const source = String(runSummary.source ?? backtestSummary.source ?? 'unknown');
+
+  const rejectionByReason = guardRejections.reduce<Record<string, number>>((acc, row) => {
+    row.reasons.forEach((r) => {
+      acc[r] = (acc[r] ?? 0) + 1;
+    });
+    return acc;
+  }, {});
+
+  const trainVsTest = {
+    trainRoi: Number(trainSummary.roi ?? 0),
+    testRoi: Number(testSummary.roi ?? 0),
+    trainWinRate: Number(trainSummary.winRate ?? 0),
+    testWinRate: Number(testSummary.winRate ?? 0)
+  };
+
+  const md = `# Run Report
+
+- **Run mode:** ${mode}
+- **Source:** ${source}
+- **Final bankroll:** ${finalBankroll.toFixed(2)}
+- **ROI:** ${toPct(roi)}
+- **Win rate:** ${toPct(winRate)}
+- **Max drawdown:** ${maxDrawdown.toFixed(2)}
+- **Profit factor:** ${profitFactor.toFixed(4)}
+- **Sharpe-like score:** ${sharpeLike.toFixed(4)}
+
+## Top accepted trades
+
+${topAcceptedTrades.map((t) => `- ${JSON.stringify(t)}`).join('\n') || '- none'}
+
+## Rejected trades by guardrail reason
+
+${Object.entries(rejectionByReason).map(([k, v]) => `- ${k}: ${v}`).join('\n') || '- none'}
+
+## Train vs Test comparison
+
+- train ROI: ${toPct(trainVsTest.trainRoi)}
+- test ROI: ${toPct(trainVsTest.testRoi)}
+- train win rate: ${toPct(trainVsTest.trainWinRate)}
+- test win rate: ${toPct(trainVsTest.testWinRate)}
+
+## LLM research summary
+
+- enabled: ${String(runSummary.llm_enabled ?? false)}
+- llm reports generated: ${llmResearch.length}
+`;
+
+  const htmlRows = topAcceptedTrades
+    .map((t) => `<tr><td>${String(t.marketId ?? t.id ?? '')}</td><td>${String(t.pnl ?? '')}</td><td>${String(t.roi ?? '')}</td></tr>`)
+    .join('');
+
+  const html = `<!doctype html><html><head><meta charset="utf-8"><title>Run Report</title></head><body>
+<h1>Run Report</h1>
+<table border="1"><tr><th>Metric</th><th>Value</th></tr>
+<tr><td>Run mode</td><td>${mode}</td></tr>
+<tr><td>Source</td><td>${source}</td></tr>
+<tr><td>Final bankroll</td><td>${finalBankroll.toFixed(2)}</td></tr>
+<tr><td>ROI</td><td>${toPct(roi)}</td></tr>
+<tr><td>Win rate</td><td>${toPct(winRate)}</td></tr>
+<tr><td>Max drawdown</td><td>${maxDrawdown.toFixed(2)}</td></tr>
+<tr><td>Profit factor</td><td>${profitFactor.toFixed(4)}</td></tr>
+<tr><td>Sharpe-like</td><td>${sharpeLike.toFixed(4)}</td></tr>
+</table>
+<h2>Top accepted trades</h2>
+<table border="1"><tr><th>Market</th><th>PnL</th><th>ROI</th></tr>${htmlRows}</table>
+<h2>Rejected by guardrail</h2>
+<ul>${Object.entries(rejectionByReason).map(([k, v]) => `<li>${k}: ${v}</li>`).join('') || '<li>none</li>'}</ul>
+<h2>Train vs Test</h2>
+<table border="1"><tr><th>Split</th><th>ROI</th><th>Win Rate</th></tr>
+<tr><td>Train</td><td>${toPct(trainVsTest.trainRoi)}</td><td>${toPct(trainVsTest.trainWinRate)}</td></tr>
+<tr><td>Test</td><td>${toPct(trainVsTest.testRoi)}</td><td>${toPct(trainVsTest.testWinRate)}</td></tr>
+</table>
+<h2>LLM Summary</h2><p>Enabled: ${String(runSummary.llm_enabled ?? false)}, Reports: ${llmResearch.length}</p>
+</body></html>`;
+
+  const mdPath = path.join(dir, 'report.md');
+  const htmlPath = path.join(dir, 'report.html');
+  fs.writeFileSync(mdPath, md);
+  fs.writeFileSync(htmlPath, html);
+
+  return { mdPath, htmlPath };
+};

--- a/paper-trading-mvp/src/reporting/reportBuilder.ts
+++ b/paper-trading-mvp/src/reporting/reportBuilder.ts
@@ -31,6 +31,11 @@ export const buildReportArtifacts = ({ mode, artifactsDir }: BuildReportInput): 
     path.join(dir, 'comparison_summary.json'),
     {}
   );
+  const pipelineDiagnostics = safeRead<{
+    funnel?: Record<string, number>;
+    topBlockers?: Array<{ stage: string; reason: string; count: number }>;
+    nearMissCandidates?: Array<Record<string, unknown>>;
+  }>(path.join(dir, 'pipeline_diagnostics.json'), {});
 
   const topAcceptedTrades =
     mode === 'backtest'
@@ -133,6 +138,27 @@ ${Object.entries(rejectionByReason).map(([k, v]) => `- ${k}: ${v}`).join('\n') |
 - real rejection rate: ${comparison.real ? toPct(Number(comparison.real.rejectionRate ?? 0)) : 'N/A'}
 - signal verdict: ${String(comparison.verdict ?? 'N/A')}
 - no signal reasons: ${(comparison.reasons ?? []).join('; ') || 'none'}
+
+## Pipeline Diagnostics
+
+| Stage | Count |
+| --- | ---: |
+| markets loaded | ${Number(pipelineDiagnostics.funnel?.marketsLoaded ?? 0)} |
+| scanner passed | ${Number(pipelineDiagnostics.funnel?.scannerPassed ?? 0)} |
+| research passed | ${Number(pipelineDiagnostics.funnel?.researchPassed ?? 0)} |
+| wallet signals available | ${Number(pipelineDiagnostics.funnel?.walletSignalsAvailable ?? 0)} |
+| strategy candidates | ${Number(pipelineDiagnostics.funnel?.strategyCandidates ?? 0)} |
+| risk-approved trades | ${Number(pipelineDiagnostics.funnel?.riskApproved ?? 0)} |
+| guardrail-approved trades | ${Number(pipelineDiagnostics.funnel?.guardrailApproved ?? 0)} |
+| final executed trades | ${Number(pipelineDiagnostics.funnel?.executedTrades ?? 0)} |
+
+### Biggest blockers
+
+${(pipelineDiagnostics.topBlockers ?? []).map((b) => `- ${b.stage}: ${b.reason} (${b.count})`).join('\n') || '- none'}
+
+### Near-miss opportunities
+
+${(pipelineDiagnostics.nearMissCandidates ?? []).slice(0, 20).map((n) => `- ${String(n.marketId ?? '')}: stage=${String(n.failedStage ?? '')}, reason=${String(n.failedReason ?? '')}, edge=${Number(n.edge ?? 0).toFixed(4)}, edgeAfterSlippage=${Number(n.edgeAfterSlippage ?? 0).toFixed(4)}, liquidity=${Number(n.liquidity ?? 0)}, spread=${Number(n.spread ?? 0).toFixed(4)}, timeToResolution=${Number(n.timeToResolutionHours ?? 0).toFixed(2)}h, walletSignal=${Number(n.walletSignal ?? 0).toFixed(2)}`).join('\n') || '- none'}
 `;
 
   const htmlRows = topAcceptedTrades
@@ -172,6 +198,21 @@ ${Object.entries(rejectionByReason).map(([k, v]) => `- ${k}: ${v}`).join('\n') |
 </table>
 <p><strong>Signal verdict:</strong> ${String(comparison.verdict ?? 'N/A')}</p>
 <p><strong>No-signal reasons:</strong> ${(comparison.reasons ?? []).join('; ') || 'none'}</p>
+<h2>Pipeline Diagnostics</h2>
+<table border="1"><tr><th>Stage</th><th>Count</th></tr>
+<tr><td>Markets loaded</td><td>${Number(pipelineDiagnostics.funnel?.marketsLoaded ?? 0)}</td></tr>
+<tr><td>Scanner passed</td><td>${Number(pipelineDiagnostics.funnel?.scannerPassed ?? 0)}</td></tr>
+<tr><td>Research passed</td><td>${Number(pipelineDiagnostics.funnel?.researchPassed ?? 0)}</td></tr>
+<tr><td>Wallet signals available</td><td>${Number(pipelineDiagnostics.funnel?.walletSignalsAvailable ?? 0)}</td></tr>
+<tr><td>Strategy candidates</td><td>${Number(pipelineDiagnostics.funnel?.strategyCandidates ?? 0)}</td></tr>
+<tr><td>Risk-approved trades</td><td>${Number(pipelineDiagnostics.funnel?.riskApproved ?? 0)}</td></tr>
+<tr><td>Guardrail-approved trades</td><td>${Number(pipelineDiagnostics.funnel?.guardrailApproved ?? 0)}</td></tr>
+<tr><td>Final executed trades</td><td>${Number(pipelineDiagnostics.funnel?.executedTrades ?? 0)}</td></tr>
+</table>
+<h3>Biggest blockers</h3>
+<ul>${(pipelineDiagnostics.topBlockers ?? []).map((b) => `<li>${b.stage}: ${b.reason} (${b.count})</li>`).join('') || '<li>none</li>'}</ul>
+<h3>Near-miss opportunities</h3>
+<ul>${(pipelineDiagnostics.nearMissCandidates ?? []).slice(0, 20).map((n) => `<li>${String(n.marketId ?? '')}: stage=${String(n.failedStage ?? '')}, reason=${String(n.failedReason ?? '')}, edge=${Number(n.edge ?? 0).toFixed(4)}, edgeAfterSlippage=${Number(n.edgeAfterSlippage ?? 0).toFixed(4)}, liquidity=${Number(n.liquidity ?? 0)}, spread=${Number(n.spread ?? 0).toFixed(4)}, timeToResolution=${Number(n.timeToResolutionHours ?? 0).toFixed(2)}h, walletSignal=${Number(n.walletSignal ?? 0).toFixed(2)}</li>`).join('') || '<li>none</li>'}</ul>
 </body></html>`;
 
   const mdPath = path.join(dir, 'report.md');

--- a/paper-trading-mvp/src/reporting/reportBuilder.ts
+++ b/paper-trading-mvp/src/reporting/reportBuilder.ts
@@ -27,6 +27,10 @@ export const buildReportArtifacts = ({ mode, artifactsDir }: BuildReportInput): 
   const llmResearch = safeRead<Array<Record<string, unknown>>>(path.join(dir, 'llm_research.json'), []);
   const ledger = safeRead<{ trades?: Array<Record<string, unknown>>; bankroll?: number }>(path.join(dir, 'paper_ledger.json'), {});
   const dataQuality = safeRead<{ criticalIssues?: string[]; warnings?: string[] }>(path.join(dir, 'data_quality_report.json'), {});
+  const comparison = safeRead<{ verdict?: string; reasons?: string[]; sample?: Record<string, number>; real?: Record<string, number> }>(
+    path.join(dir, 'comparison_summary.json'),
+    {}
+  );
 
   const topAcceptedTrades =
     mode === 'backtest'
@@ -114,6 +118,21 @@ ${Object.entries(rejectionByReason).map(([k, v]) => `- ${k}: ${v}`).join('\n') |
 
 - critical issues: ${(dataQuality.criticalIssues ?? []).join(', ') || 'none'}
 - warnings: ${(dataQuality.warnings ?? []).join(', ') || 'none'}
+
+## Reality Check
+
+- sample ROI: ${comparison.sample ? toPct(Number(comparison.sample.roi ?? 0)) : 'N/A'}
+- real ROI: ${comparison.real ? toPct(Number(comparison.real.roi ?? 0)) : 'N/A'}
+- sample win rate: ${comparison.sample ? toPct(Number(comparison.sample.winRate ?? 0)) : 'N/A'}
+- real win rate: ${comparison.real ? toPct(Number(comparison.real.winRate ?? 0)) : 'N/A'}
+- sample drawdown: ${comparison.sample ? Number(comparison.sample.maxDrawdown ?? 0).toFixed(2) : 'N/A'}
+- real drawdown: ${comparison.real ? Number(comparison.real.maxDrawdown ?? 0).toFixed(2) : 'N/A'}
+- sample trade count: ${comparison.sample ? Number(comparison.sample.tradeCount ?? 0) : 'N/A'}
+- real trade count: ${comparison.real ? Number(comparison.real.tradeCount ?? 0) : 'N/A'}
+- sample rejection rate: ${comparison.sample ? toPct(Number(comparison.sample.rejectionRate ?? 0)) : 'N/A'}
+- real rejection rate: ${comparison.real ? toPct(Number(comparison.real.rejectionRate ?? 0)) : 'N/A'}
+- signal verdict: ${String(comparison.verdict ?? 'N/A')}
+- no signal reasons: ${(comparison.reasons ?? []).join('; ') || 'none'}
 `;
 
   const htmlRows = topAcceptedTrades
@@ -143,6 +162,16 @@ ${Object.entries(rejectionByReason).map(([k, v]) => `- ${k}: ${v}`).join('\n') |
 </table>
 <h2>LLM Summary</h2><p>Enabled: ${String(runSummary.llm_enabled ?? false)}, Reports: ${llmResearch.length}</p>
 <h2>Data Quality</h2><p>Critical: ${(dataQuality.criticalIssues ?? []).join(', ') || 'none'}</p><p>Warnings: ${(dataQuality.warnings ?? []).join(', ') || 'none'}</p>
+<h2>Reality Check</h2>
+<table border="1"><tr><th>Metric</th><th>Sample</th><th>Real</th></tr>
+<tr><td>ROI</td><td>${comparison.sample ? toPct(Number(comparison.sample.roi ?? 0)) : 'N/A'}</td><td>${comparison.real ? toPct(Number(comparison.real.roi ?? 0)) : 'N/A'}</td></tr>
+<tr><td>Win rate</td><td>${comparison.sample ? toPct(Number(comparison.sample.winRate ?? 0)) : 'N/A'}</td><td>${comparison.real ? toPct(Number(comparison.real.winRate ?? 0)) : 'N/A'}</td></tr>
+<tr><td>Drawdown</td><td>${comparison.sample ? Number(comparison.sample.maxDrawdown ?? 0).toFixed(2) : 'N/A'}</td><td>${comparison.real ? Number(comparison.real.maxDrawdown ?? 0).toFixed(2) : 'N/A'}</td></tr>
+<tr><td>Trade count</td><td>${comparison.sample ? Number(comparison.sample.tradeCount ?? 0) : 'N/A'}</td><td>${comparison.real ? Number(comparison.real.tradeCount ?? 0) : 'N/A'}</td></tr>
+<tr><td>Rejection rate</td><td>${comparison.sample ? toPct(Number(comparison.sample.rejectionRate ?? 0)) : 'N/A'}</td><td>${comparison.real ? toPct(Number(comparison.real.rejectionRate ?? 0)) : 'N/A'}</td></tr>
+</table>
+<p><strong>Signal verdict:</strong> ${String(comparison.verdict ?? 'N/A')}</p>
+<p><strong>No-signal reasons:</strong> ${(comparison.reasons ?? []).join('; ') || 'none'}</p>
 </body></html>`;
 
   const mdPath = path.join(dir, 'report.md');

--- a/paper-trading-mvp/src/reporting/reportBuilder.ts
+++ b/paper-trading-mvp/src/reporting/reportBuilder.ts
@@ -26,6 +26,7 @@ export const buildReportArtifacts = ({ mode, artifactsDir }: BuildReportInput): 
   const guardRejections = safeRead<Array<{ marketId: string; reasons: string[] }>>(path.join(dir, 'guardrail_rejections.json'), []);
   const llmResearch = safeRead<Array<Record<string, unknown>>>(path.join(dir, 'llm_research.json'), []);
   const ledger = safeRead<{ trades?: Array<Record<string, unknown>>; bankroll?: number }>(path.join(dir, 'paper_ledger.json'), {});
+  const dataQuality = safeRead<{ criticalIssues?: string[]; warnings?: string[] }>(path.join(dir, 'data_quality_report.json'), {});
 
   const topAcceptedTrades =
     mode === 'backtest'
@@ -108,6 +109,11 @@ ${Object.entries(rejectionByReason).map(([k, v]) => `- ${k}: ${v}`).join('\n') |
 
 - enabled: ${String(runSummary.llm_enabled ?? false)}
 - llm reports generated: ${llmResearch.length}
+
+## Data quality diagnostics
+
+- critical issues: ${(dataQuality.criticalIssues ?? []).join(', ') || 'none'}
+- warnings: ${(dataQuality.warnings ?? []).join(', ') || 'none'}
 `;
 
   const htmlRows = topAcceptedTrades
@@ -136,6 +142,7 @@ ${Object.entries(rejectionByReason).map(([k, v]) => `- ${k}: ${v}`).join('\n') |
 <tr><td>Test</td><td>${toPct(trainVsTest.testRoi)}</td><td>${toPct(trainVsTest.testWinRate)}</td></tr>
 </table>
 <h2>LLM Summary</h2><p>Enabled: ${String(runSummary.llm_enabled ?? false)}, Reports: ${llmResearch.length}</p>
+<h2>Data Quality</h2><p>Critical: ${(dataQuality.criticalIssues ?? []).join(', ') || 'none'}</p><p>Warnings: ${(dataQuality.warnings ?? []).join(', ') || 'none'}</p>
 </body></html>`;
 
   const mdPath = path.join(dir, 'report.md');

--- a/paper-trading-mvp/src/types/market.ts
+++ b/paper-trading-mvp/src/types/market.ts
@@ -1,0 +1,19 @@
+export type MarketCategory = 'politics' | 'sports' | 'crypto' | 'macro' | 'other';
+
+export interface Market {
+  id: string;
+  question: string;
+  category: MarketCategory;
+  currentPrice: number;
+  spread: number;
+  liquidity: number;
+  volume24h: number;
+  resolutionAt: string;
+}
+
+export interface ScoredMarket extends Market {
+  estimatedProbability: number;
+  estimatedEdge: number;
+  scannerPass: boolean;
+  scannerReasons: string[];
+}

--- a/paper-trading-mvp/src/types/market.ts
+++ b/paper-trading-mvp/src/types/market.ts
@@ -9,6 +9,7 @@ export interface Market {
   liquidity: number;
   volume24h: number;
   resolutionAt: string;
+  lastPriceUpdatedAt?: string;
 }
 
 export interface ScoredMarket extends Market {

--- a/paper-trading-mvp/src/types/signal.ts
+++ b/paper-trading-mvp/src/types/signal.ts
@@ -1,0 +1,23 @@
+export type SignalDirection = 'yes' | 'no' | 'none';
+
+export interface ResearchReport {
+  market_id: string;
+  question: string;
+  current_price: number;
+  estimated_probability: number;
+  edge: number;
+  confidence: number;
+  reasoning_summary: string;
+  risk_flags: string[];
+  pass: boolean;
+}
+
+export interface StrategyDecision {
+  marketId: string;
+  direction: SignalDirection;
+  strategy: 'convergence' | 'arbitrage_placeholder' | 'copy_trade_placeholder' | 'none';
+  consensusCount: number;
+  confidence: number;
+  desiredExposure: number;
+  rationale: string;
+}

--- a/paper-trading-mvp/src/types/signal.ts
+++ b/paper-trading-mvp/src/types/signal.ts
@@ -12,6 +12,15 @@ export interface ResearchReport {
   pass: boolean;
 }
 
+export interface LlmResearchReport {
+  marketId: string;
+  estimatedProbability: number;
+  confidence: number;
+  reasoningSummary: string;
+  riskFlags: string[];
+  pass: boolean;
+}
+
 export interface StrategyDecision {
   marketId: string;
   direction: SignalDirection;

--- a/paper-trading-mvp/src/types/trade.ts
+++ b/paper-trading-mvp/src/types/trade.ts
@@ -1,0 +1,27 @@
+export interface SimulatedTrade {
+  id: string;
+  marketId: string;
+  question: string;
+  direction: 'yes' | 'no';
+  entryPrice: number;
+  positionSize: number;
+  quantity: number;
+  openedAt: string;
+  maxHoldingMinutes: number;
+}
+
+export interface ClosedTrade extends SimulatedTrade {
+  exitPrice: number;
+  closedAt: string;
+  pnl: number;
+  roi: number;
+  exitReason: 'target_hit' | 'stop_loss' | 'stale_thesis' | 'volume_spike_placeholder' | 'max_holding_time';
+}
+
+export interface PaperMetrics {
+  finalBankroll: number;
+  totalPnl: number;
+  winRate: number;
+  maxDrawdown: number;
+  sharpeLike: number;
+}

--- a/paper-trading-mvp/src/types/trade.ts
+++ b/paper-trading-mvp/src/types/trade.ts
@@ -1,3 +1,14 @@
+import { MarketCategory } from './market';
+
+export interface HistoricalTrade {
+  wallet: string;
+  marketId: string;
+  category: MarketCategory;
+  stake: number;
+  payout: number;
+  timestamp: string;
+}
+
 export interface SimulatedTrade {
   id: string;
   marketId: string;

--- a/paper-trading-mvp/src/types/wallet.ts
+++ b/paper-trading-mvp/src/types/wallet.ts
@@ -1,0 +1,21 @@
+import { MarketCategory } from './market';
+
+export interface WalletTrade {
+  wallet: string;
+  marketId: string;
+  category: MarketCategory;
+  stake: number;
+  payout: number;
+  timestamp: string;
+}
+
+export interface WalletScore {
+  wallet: string;
+  numberOfTrades: number;
+  winRate: number;
+  realizedProfit: number;
+  maxDrawdown: number;
+  categoryConsistency: number;
+  trustedSample: boolean;
+  rankScore: number;
+}

--- a/paper-trading-mvp/src/types/wallet.ts
+++ b/paper-trading-mvp/src/types/wallet.ts
@@ -1,21 +1,17 @@
-import { MarketCategory } from './market';
+import { HistoricalTrade } from './trade';
 
-export interface WalletTrade {
-  wallet: string;
-  marketId: string;
-  category: MarketCategory;
-  stake: number;
-  payout: number;
-  timestamp: string;
-}
+export type WalletTrade = HistoricalTrade;
 
 export interface WalletScore {
   wallet: string;
-  numberOfTrades: number;
+  totalTrades: number;
   winRate: number;
-  realizedProfit: number;
+  realizedPnl: number;
+  roi: number;
+  averageTradeSize: number;
   maxDrawdown: number;
-  categoryConsistency: number;
+  categoryConcentration: number;
+  confidenceScore: number;
   trustedSample: boolean;
   rankScore: number;
 }

--- a/paper-trading-mvp/src/utils/cli.ts
+++ b/paper-trading-mvp/src/utils/cli.ts
@@ -1,6 +1,8 @@
 import { MarketSourceType } from '../config/defaultConfig';
 import { TradeSourceType } from '../data/polymarketTradeHistorySource';
 
+export type RunMode = 'paper' | 'backtest';
+
 export interface CliArgs {
   marketsPath?: string;
   bankroll?: number;
@@ -8,6 +10,7 @@ export interface CliArgs {
   source?: MarketSourceType;
   tradeSource?: TradeSourceType;
   tradeFile?: string;
+  mode?: RunMode;
 }
 
 export const parseCliArgs = (argv: string[]): CliArgs => {
@@ -20,6 +23,12 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (token === '--markets') args.marketsPath = next;
     if (token === '--trade-file') args.tradeFile = next;
     if (token === '--config') args.configPath = next;
+    if (token === '--mode') {
+      if (next !== 'paper' && next !== 'backtest') {
+        throw new Error(`Unsupported mode '${next}'. Use 'paper' or 'backtest'.`);
+      }
+      args.mode = next;
+    }
     if (token === '--source') {
       if (next !== 'sample' && next !== 'polymarket') {
         throw new Error(`Unsupported source '${next}'. Use 'sample' or 'polymarket'.`);

--- a/paper-trading-mvp/src/utils/cli.ts
+++ b/paper-trading-mvp/src/utils/cli.ts
@@ -1,11 +1,13 @@
 import { MarketSourceType } from '../config/defaultConfig';
+import { TradeSourceType } from '../data/polymarketTradeHistorySource';
 
 export interface CliArgs {
   marketsPath?: string;
-  tradesPath?: string;
   bankroll?: number;
   configPath?: string;
   source?: MarketSourceType;
+  tradeSource?: TradeSourceType;
+  tradeFile?: string;
 }
 
 export const parseCliArgs = (argv: string[]): CliArgs => {
@@ -16,13 +18,19 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     const next = argv[i + 1];
 
     if (token === '--markets') args.marketsPath = next;
-    if (token === '--trades') args.tradesPath = next;
+    if (token === '--trade-file') args.tradeFile = next;
     if (token === '--config') args.configPath = next;
     if (token === '--source') {
       if (next !== 'sample' && next !== 'polymarket') {
         throw new Error(`Unsupported source '${next}'. Use 'sample' or 'polymarket'.`);
       }
       args.source = next;
+    }
+    if (token === '--trade-source') {
+      if (next !== 'sample' && next !== 'csv' && next !== 'json') {
+        throw new Error(`Unsupported trade source '${next}'. Use 'sample', 'csv', or 'json'.`);
+      }
+      args.tradeSource = next;
     }
     if (token === '--bankroll') {
       const parsed = Number(next);

--- a/paper-trading-mvp/src/utils/cli.ts
+++ b/paper-trading-mvp/src/utils/cli.ts
@@ -1,0 +1,28 @@
+export interface CliArgs {
+  marketsPath?: string;
+  tradesPath?: string;
+  bankroll?: number;
+  configPath?: string;
+}
+
+export const parseCliArgs = (argv: string[]): CliArgs => {
+  const args: CliArgs = {};
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const next = argv[i + 1];
+
+    if (token === '--markets') args.marketsPath = next;
+    if (token === '--trades') args.tradesPath = next;
+    if (token === '--config') args.configPath = next;
+    if (token === '--bankroll') {
+      const parsed = Number(next);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error(`Invalid --bankroll value '${next}'. Must be a positive number.`);
+      }
+      args.bankroll = parsed;
+    }
+  }
+
+  return args;
+};

--- a/paper-trading-mvp/src/utils/cli.ts
+++ b/paper-trading-mvp/src/utils/cli.ts
@@ -12,6 +12,7 @@ export interface CliArgs {
   tradeFile?: string;
   mode?: RunMode;
   llm?: 'on' | 'off';
+  strictData?: 'on' | 'off';
 }
 
 export const parseCliArgs = (argv: string[]): CliArgs => {
@@ -24,6 +25,10 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (token === '--markets') args.marketsPath = next;
     if (token === '--trade-file') args.tradeFile = next;
     if (token === '--config') args.configPath = next;
+    if (token === '--strict-data') {
+      if (next !== 'on' && next !== 'off') throw new Error(`Unsupported --strict-data value '${next}'. Use 'on' or 'off'.`);
+      args.strictData = next;
+    }
     if (token === '--llm') {
       if (next !== 'on' && next !== 'off') throw new Error(`Unsupported --llm value '${next}'. Use 'on' or 'off'.`);
       args.llm = next;

--- a/paper-trading-mvp/src/utils/cli.ts
+++ b/paper-trading-mvp/src/utils/cli.ts
@@ -1,8 +1,11 @@
+import { MarketSourceType } from '../config/defaultConfig';
+
 export interface CliArgs {
   marketsPath?: string;
   tradesPath?: string;
   bankroll?: number;
   configPath?: string;
+  source?: MarketSourceType;
 }
 
 export const parseCliArgs = (argv: string[]): CliArgs => {
@@ -15,6 +18,12 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (token === '--markets') args.marketsPath = next;
     if (token === '--trades') args.tradesPath = next;
     if (token === '--config') args.configPath = next;
+    if (token === '--source') {
+      if (next !== 'sample' && next !== 'polymarket') {
+        throw new Error(`Unsupported source '${next}'. Use 'sample' or 'polymarket'.`);
+      }
+      args.source = next;
+    }
     if (token === '--bankroll') {
       const parsed = Number(next);
       if (!Number.isFinite(parsed) || parsed <= 0) {

--- a/paper-trading-mvp/src/utils/cli.ts
+++ b/paper-trading-mvp/src/utils/cli.ts
@@ -11,6 +11,7 @@ export interface CliArgs {
   tradeSource?: TradeSourceType;
   tradeFile?: string;
   mode?: RunMode;
+  llm?: 'on' | 'off';
 }
 
 export const parseCliArgs = (argv: string[]): CliArgs => {
@@ -23,6 +24,10 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
     if (token === '--markets') args.marketsPath = next;
     if (token === '--trade-file') args.tradeFile = next;
     if (token === '--config') args.configPath = next;
+    if (token === '--llm') {
+      if (next !== 'on' && next !== 'off') throw new Error(`Unsupported --llm value '${next}'. Use 'on' or 'off'.`);
+      args.llm = next;
+    }
     if (token === '--mode') {
       if (next !== 'paper' && next !== 'backtest') {
         throw new Error(`Unsupported mode '${next}'. Use 'paper' or 'backtest'.`);

--- a/paper-trading-mvp/src/utils/cli.ts
+++ b/paper-trading-mvp/src/utils/cli.ts
@@ -1,7 +1,7 @@
 import { MarketSourceType } from '../config/defaultConfig';
 import { TradeSourceType } from '../data/polymarketTradeHistorySource';
 
-export type RunMode = 'paper' | 'backtest';
+export type RunMode = 'paper' | 'backtest' | 'import';
 
 export interface CliArgs {
   marketsPath?: string;
@@ -13,6 +13,9 @@ export interface CliArgs {
   mode?: RunMode;
   llm?: 'on' | 'off';
   strictData?: 'on' | 'off';
+  input?: string;
+  inputType?: 'markets' | 'trades' | 'fills';
+  output?: string;
 }
 
 export const parseCliArgs = (argv: string[]): CliArgs => {
@@ -34,8 +37,8 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
       args.llm = next;
     }
     if (token === '--mode') {
-      if (next !== 'paper' && next !== 'backtest') {
-        throw new Error(`Unsupported mode '${next}'. Use 'paper' or 'backtest'.`);
+      if (next !== 'paper' && next !== 'backtest' && next !== 'import') {
+        throw new Error(`Unsupported mode '${next}'. Use 'paper', 'backtest', or 'import'.`);
       }
       args.mode = next;
     }
@@ -46,11 +49,21 @@ export const parseCliArgs = (argv: string[]): CliArgs => {
       args.source = next;
     }
     if (token === '--trade-source') {
-      if (next !== 'sample' && next !== 'csv' && next !== 'json') {
-        throw new Error(`Unsupported trade source '${next}'. Use 'sample', 'csv', or 'json'.`);
+      if (next !== 'sample' && next !== 'csv' && next !== 'json' && next !== 'fills') {
+        throw new Error(`Unsupported trade source '${next}'. Use 'sample', 'csv', 'json', or 'fills'.`);
       }
       args.tradeSource = next;
     }
+
+    if (token === '--input') args.input = next;
+    if (token === '--output') args.output = next;
+    if (token === '--input-type') {
+      if (next !== 'markets' && next !== 'trades' && next !== 'fills') {
+        throw new Error(`Unsupported --input-type value '${next}'. Use 'markets', 'trades', or 'fills'.`);
+      }
+      args.inputType = next;
+    }
+
     if (token === '--bankroll') {
       const parsed = Number(next);
       if (!Number.isFinite(parsed) || parsed <= 0) {

--- a/paper-trading-mvp/src/utils/io.ts
+++ b/paper-trading-mvp/src/utils/io.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const ensureFileExists = (filePath: string): void => {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Required file does not exist: ${filePath}`);
+  }
+};
+
+export const ensureDir = (dirPath: string): void => {
+  fs.mkdirSync(dirPath, { recursive: true });
+};
+
+export const readJson = (filePath: string): unknown => {
+  ensureFileExists(filePath);
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as unknown;
+  } catch (error) {
+    throw new Error(`Unable to parse JSON at ${filePath}: ${(error as Error).message}`);
+  }
+};
+
+export const writeJson = (filePath: string, data: unknown): void => {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+};

--- a/paper-trading-mvp/src/utils/validation.ts
+++ b/paper-trading-mvp/src/utils/validation.ts
@@ -1,0 +1,63 @@
+import { Market } from '../types/market';
+import { WalletTrade } from '../types/wallet';
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const assertNumber = (value: unknown, field: string): number => {
+  if (typeof value !== 'number' || Number.isNaN(value) || !Number.isFinite(value)) {
+    throw new Error(`Invalid number for field '${field}'.`);
+  }
+  return value;
+};
+
+const assertString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Invalid string for field '${field}'.`);
+  }
+  return value;
+};
+
+export const validateMarkets = (input: unknown): Market[] => {
+  if (!Array.isArray(input)) throw new Error('Markets JSON must be an array.');
+  if (input.length === 0) throw new Error('Markets JSON is empty.');
+
+  return input.map((item, idx) => {
+    if (!isObject(item)) throw new Error(`Market at index ${idx} must be an object.`);
+    const resolutionAt = assertString(item.resolutionAt, `markets[${idx}].resolutionAt`);
+    if (Number.isNaN(new Date(resolutionAt).getTime())) {
+      throw new Error(`Invalid date for markets[${idx}].resolutionAt.`);
+    }
+
+    return {
+      id: assertString(item.id, `markets[${idx}].id`),
+      question: assertString(item.question, `markets[${idx}].question`),
+      category: assertString(item.category, `markets[${idx}].category`) as Market['category'],
+      currentPrice: assertNumber(item.currentPrice, `markets[${idx}].currentPrice`),
+      spread: assertNumber(item.spread, `markets[${idx}].spread`),
+      liquidity: assertNumber(item.liquidity, `markets[${idx}].liquidity`),
+      volume24h: assertNumber(item.volume24h, `markets[${idx}].volume24h`),
+      resolutionAt
+    };
+  });
+};
+
+export const validateWalletTrades = (input: unknown): WalletTrade[] => {
+  if (!Array.isArray(input)) throw new Error('Trades JSON must be an array.');
+  return input.map((item, idx) => {
+    if (!isObject(item)) throw new Error(`Trade at index ${idx} must be an object.`);
+    const timestamp = assertString(item.timestamp, `trades[${idx}].timestamp`);
+    if (Number.isNaN(new Date(timestamp).getTime())) {
+      throw new Error(`Invalid date for trades[${idx}].timestamp.`);
+    }
+
+    return {
+      wallet: assertString(item.wallet, `trades[${idx}].wallet`),
+      marketId: assertString(item.marketId, `trades[${idx}].marketId`),
+      category: assertString(item.category, `trades[${idx}].category`) as WalletTrade['category'],
+      stake: assertNumber(item.stake, `trades[${idx}].stake`),
+      payout: assertNumber(item.payout, `trades[${idx}].payout`),
+      timestamp
+    };
+  });
+};

--- a/paper-trading-mvp/src/validation/dataQuality.ts
+++ b/paper-trading-mvp/src/validation/dataQuality.ts
@@ -1,0 +1,71 @@
+import path from 'node:path';
+import { Market } from '../types/market';
+import { WalletTrade } from '../types/wallet';
+import { writeJson } from '../utils/io';
+
+export interface DataQualityReport {
+  criticalIssues: string[];
+  warnings: string[];
+  stats: {
+    marketCount: number;
+    tradeCount: number;
+    unmatchedMarkets: number;
+    unmatchedTrades: number;
+  };
+}
+
+export const analyzeDataQuality = (markets: Market[], trades: WalletTrade[]): DataQualityReport => {
+  const criticalIssues: string[] = [];
+  const warnings: string[] = [];
+
+  const marketIds = markets.map((m) => m.id);
+  const duplicateMarketIds = marketIds.filter((id, idx) => marketIds.indexOf(id) !== idx);
+  if (duplicateMarketIds.length > 0) criticalIssues.push(`duplicate_market_ids:${Array.from(new Set(duplicateMarketIds)).join(',')}`);
+
+  const tradeKeys = trades.map((t) => `${t.wallet}|${t.marketId}|${t.timestamp}|${t.stake}|${t.payout}`);
+  const duplicateTrades = tradeKeys.filter((k, idx) => tradeKeys.indexOf(k) !== idx);
+  if (duplicateTrades.length > 0) warnings.push(`duplicate_trades:${duplicateTrades.length}`);
+
+  const missingTimestamps = trades.filter((t) => !t.timestamp || Number.isNaN(new Date(t.timestamp).getTime())).length;
+  if (missingTimestamps > 0) criticalIssues.push(`missing_or_invalid_timestamps:${missingTimestamps}`);
+
+  const futureTimestamps = trades.filter((t) => new Date(t.timestamp).getTime() > Date.now()).length;
+  if (futureTimestamps > 0) warnings.push(`future_timestamps:${futureTimestamps}`);
+
+  const negativePrices = markets.filter((m) => m.currentPrice < 0).length;
+  if (negativePrices > 0) criticalIssues.push(`negative_prices:${negativePrices}`);
+
+  const outsideRangePrices = markets.filter((m) => m.currentPrice > 1 || m.currentPrice < 0).length;
+  if (outsideRangePrices > 0) criticalIssues.push(`prices_outside_0_1:${outsideRangePrices}`);
+
+  const missingLiquidity = markets.filter((m) => !Number.isFinite(m.liquidity) || m.liquidity <= 0).length;
+  if (missingLiquidity > 0) warnings.push(`missing_or_invalid_liquidity:${missingLiquidity}`);
+
+  const sizes = trades.map((t) => t.stake).filter((n) => Number.isFinite(n));
+  const median = sizes.length === 0 ? 0 : [...sizes].sort((a, b) => a - b)[Math.floor(sizes.length / 2)];
+  const outliers = sizes.filter((s) => median > 0 && s > median * 10).length;
+  if (outliers > 0) warnings.push(`extreme_trade_size_outliers:${outliers}`);
+
+  const tradeMarketSet = new Set(trades.map((t) => t.marketId));
+  const marketsWithoutTrades = markets.filter((m) => !tradeMarketSet.has(m.id)).length;
+  if (marketsWithoutTrades > 0) warnings.push(`markets_with_no_matching_trades:${marketsWithoutTrades}`);
+
+  const marketSet = new Set(markets.map((m) => m.id));
+  const tradesWithoutMarkets = trades.filter((t) => !marketSet.has(t.marketId)).length;
+  if (tradesWithoutMarkets > 0) warnings.push(`trades_with_no_matching_market:${tradesWithoutMarkets}`);
+
+  return {
+    criticalIssues,
+    warnings,
+    stats: {
+      marketCount: markets.length,
+      tradeCount: trades.length,
+      unmatchedMarkets: marketsWithoutTrades,
+      unmatchedTrades: tradesWithoutMarkets
+    }
+  };
+};
+
+export const persistDataQualityReport = (report: DataQualityReport, artifactsDir: string): void => {
+  writeJson(path.resolve(process.cwd(), artifactsDir, 'data_quality_report.json'), report);
+};

--- a/paper-trading-mvp/src/validation/strategyGuards.ts
+++ b/paper-trading-mvp/src/validation/strategyGuards.ts
@@ -1,0 +1,63 @@
+import { AppConfig } from '../config/defaultConfig';
+import { ScoredMarket } from '../types/market';
+import { StrategyDecision } from '../types/signal';
+import { WalletScore } from '../types/wallet';
+
+export interface SlippageEstimate {
+  estimatedSlippage: number;
+  edgeAfterSlippage: number;
+}
+
+export interface GuardrailResult {
+  allowed: boolean;
+  reasons: string[];
+  slippage: SlippageEstimate;
+}
+
+export const estimateSlippage = (liquidity: number, spread: number, tradeSize: number): SlippageEstimate => {
+  const depthFactor = tradeSize / Math.max(1, liquidity);
+  const estimatedSlippage = Math.min(0.2, depthFactor * 0.5 + spread * 0.25);
+  return {
+    estimatedSlippage,
+    edgeAfterSlippage: 0
+  };
+};
+
+export const evaluateStrategyGuards = (
+  market: ScoredMarket,
+  decision: StrategyDecision,
+  tradeSize: number,
+  walletScores: WalletScore[],
+  config: AppConfig
+): GuardrailResult => {
+  const reasons: string[] = [];
+
+  if (market.liquidity < config.guardrails.minLiquidity) reasons.push('liquidity_below_minimum');
+  if (market.spread > config.guardrails.maxSpread) reasons.push('spread_above_maximum');
+
+  const now = Date.now();
+  const hoursToResolution = (new Date(market.resolutionAt).getTime() - now) / 3_600_000;
+  if (hoursToResolution < config.guardrails.minHoursToResolution) reasons.push('too_close_to_resolution');
+
+  const lastUpdatedAt = market.lastPriceUpdatedAt ? new Date(market.lastPriceUpdatedAt).getTime() : now;
+  const staleMinutes = (now - lastUpdatedAt) / 60_000;
+  if (staleMinutes > config.guardrails.maxPriceStaleMinutes) reasons.push('stale_price_data');
+
+  const bestWalletSample = walletScores.length > 0 ? Math.max(...walletScores.map((w) => w.totalTrades)) : 0;
+  if (bestWalletSample < config.guardrails.minWalletSampleSize) reasons.push('wallet_sample_too_small');
+
+  const edgeAfterSpread = market.estimatedEdge - market.spread;
+  if (edgeAfterSpread < config.guardrails.minEdgeAfterSpread) reasons.push('edge_after_spread_too_small');
+
+  const slip = estimateSlippage(market.liquidity, market.spread, tradeSize);
+  slip.edgeAfterSlippage = edgeAfterSpread - slip.estimatedSlippage;
+  if (slip.edgeAfterSlippage <= 0) reasons.push('slippage_removes_edge');
+
+  if (decision.direction === 'none') reasons.push('no_trade_signal');
+
+  return {
+    allowed: reasons.length === 0,
+    reasons,
+    slippage: slip
+  };
+};

--- a/paper-trading-mvp/tests/backtest.test.ts
+++ b/paper-trading-mvp/tests/backtest.test.ts
@@ -33,6 +33,8 @@ test('backtest profitable replay', () => {
   const result = runBacktest([market], trades, cfg);
   assert.equal(result.summary.totalTrades > 0, true);
   assert.equal(result.summary.realizedPnl > 0, true);
+  assert.equal(typeof result.trainSummary.roi, 'number');
+  assert.equal(typeof result.testSummary.roi, 'number');
 });
 
 test('backtest losing replay', () => {

--- a/paper-trading-mvp/tests/backtest.test.ts
+++ b/paper-trading-mvp/tests/backtest.test.ts
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mergeConfig, defaultConfig } from '../src/config/defaultConfig';
+import { runBacktest } from '../src/backtest/engine';
+import { calculateMaxDrawdown } from '../src/backtest/metrics';
+
+const market = {
+  id: 'bt_m1',
+  question: 'Will test event happen?',
+  category: 'politics' as const,
+  currentPrice: 0.4,
+  spread: 0.02,
+  liquidity: 50000,
+  volume24h: 10000,
+  resolutionAt: '2026-12-31T00:00:00Z'
+};
+
+const cfg = mergeConfig(defaultConfig, {
+  walletIntel: {
+    ...defaultConfig.walletIntel,
+    minTrades: 1,
+    minConfidenceScore: 0,
+    minRealizedPnl: -1_000_000
+  }
+});
+
+test('backtest profitable replay', () => {
+  const trades = [
+    { wallet: '0xw', marketId: 'bt_m1', category: 'politics' as const, stake: 100, payout: 180, timestamp: '2026-01-01T00:00:00Z' },
+    { wallet: '0xw', marketId: 'bt_m1', category: 'politics' as const, stake: 100, payout: 160, timestamp: '2026-01-02T00:00:00Z' }
+  ];
+
+  const result = runBacktest([market], trades, cfg);
+  assert.equal(result.summary.totalTrades > 0, true);
+  assert.equal(result.summary.realizedPnl > 0, true);
+});
+
+test('backtest losing replay', () => {
+  const trades = [
+    { wallet: '0xw', marketId: 'bt_m1', category: 'politics' as const, stake: 100, payout: 20, timestamp: '2026-01-01T00:00:00Z' },
+    { wallet: '0xw', marketId: 'bt_m1', category: 'politics' as const, stake: 100, payout: 50, timestamp: '2026-01-02T00:00:00Z' }
+  ];
+
+  const result = runBacktest([market], trades, cfg);
+  assert.equal(result.summary.totalTrades > 0, true);
+  assert.equal(result.summary.realizedPnl < 0, true);
+});
+
+test('backtest no-trade replay', () => {
+  const blockedMarket = { ...market, id: 'bt_m2', category: 'other' as const };
+  const trades = [
+    { wallet: '0xw', marketId: 'bt_m2', category: 'other' as const, stake: 100, payout: 180, timestamp: '2026-01-01T00:00:00Z' }
+  ];
+
+  const result = runBacktest([blockedMarket], trades, cfg);
+  assert.equal(result.summary.totalTrades, 0);
+});
+
+test('drawdown calculation', () => {
+  const dd = calculateMaxDrawdown([100, 120, 90, 130, 110]);
+  assert.equal(dd, 30);
+});
+
+test('backtest rejects malformed historical data', () => {
+  const badTrades = [
+    { wallet: '0xw', marketId: 'bt_m1', category: 'politics' as const, stake: 100, payout: 120, timestamp: 'not-a-date' }
+  ];
+
+  assert.throws(() => runBacktest([market], badTrades, cfg), /Malformed historical trade/);
+});

--- a/paper-trading-mvp/tests/backtest.test.ts
+++ b/paper-trading-mvp/tests/backtest.test.ts
@@ -58,6 +58,21 @@ test('backtest no-trade replay', () => {
   assert.equal(result.summary.totalTrades, 0);
 });
 
+
+test('backtest emits pipeline diagnostics with stage counts and near misses', () => {
+  const blockedMarket = { ...market, id: 'bt_diag', category: 'other' as const };
+  const trades = [
+    { wallet: '0xw', marketId: 'bt_diag', category: 'other' as const, stake: 100, payout: 180, timestamp: '2026-01-01T00:00:00Z' }
+  ];
+
+  const result = runBacktest([blockedMarket], trades, cfg);
+  assert.equal(result.pipelineDiagnostics.funnel.marketsLoaded, 1);
+  assert.equal(result.pipelineDiagnostics.funnel.executedTrades, 0);
+  assert.equal(result.pipelineDiagnostics.rejectionCountsByStage.scanner > 0, true);
+  assert.equal(result.pipelineDiagnostics.nearMissCandidates.length > 0, true);
+  assert.equal(typeof result.pipelineDiagnostics.nearMissCandidates[0].failedReason, 'string');
+});
+
 test('drawdown calculation', () => {
   const dd = calculateMaxDrawdown([100, 120, 90, 130, 110]);
   assert.equal(dd, 30);

--- a/paper-trading-mvp/tests/cli.test.ts
+++ b/paper-trading-mvp/tests/cli.test.ts
@@ -12,6 +12,14 @@ test('cli parses source polymarket and trade source csv', () => {
   assert.equal(parsed.strictData, 'off');
 });
 
+test('cli parses import mode flags', () => {
+  const parsed = parseCliArgs(['--mode','import','--input','./raw.json','--input-type','markets','--output','./out.json']);
+  assert.equal(parsed.mode, 'import');
+  assert.equal(parsed.input, './raw.json');
+  assert.equal(parsed.inputType, 'markets');
+  assert.equal(parsed.output, './out.json');
+});
+
 test('cli rejects unsupported source', () => {
   assert.throws(() => parseCliArgs(['--source', 'foo']), /Unsupported source/);
 });
@@ -33,4 +41,8 @@ test('cli rejects unsupported llm flag', () => {
 
 test('cli rejects unsupported strict-data flag', () => {
   assert.throws(() => parseCliArgs(['--strict-data', 'maybe']), /Unsupported --strict-data value/);
+});
+
+test('cli rejects unsupported input-type flag', () => {
+  assert.throws(() => parseCliArgs(['--input-type', 'bad']), /Unsupported --input-type value/);
 });

--- a/paper-trading-mvp/tests/cli.test.ts
+++ b/paper-trading-mvp/tests/cli.test.ts
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseCliArgs } from '../src/utils/cli';
+
+test('cli parses source polymarket', () => {
+  const parsed = parseCliArgs(['--source', 'polymarket']);
+  assert.equal(parsed.source, 'polymarket');
+});
+
+test('cli rejects unsupported source', () => {
+  assert.throws(() => parseCliArgs(['--source', 'foo']), /Unsupported source/);
+});

--- a/paper-trading-mvp/tests/cli.test.ts
+++ b/paper-trading-mvp/tests/cli.test.ts
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict';
 import { parseCliArgs } from '../src/utils/cli';
 
 test('cli parses source polymarket and trade source csv', () => {
-  const parsed = parseCliArgs(['--source', 'polymarket', '--trade-source', 'csv', '--trade-file', './fills.csv']);
+  const parsed = parseCliArgs(['--mode','backtest','--source', 'polymarket', '--trade-source', 'csv', '--trade-file', './fills.csv']);
+  assert.equal(parsed.mode, 'backtest');
   assert.equal(parsed.source, 'polymarket');
   assert.equal(parsed.tradeSource, 'csv');
   assert.equal(parsed.tradeFile, './fills.csv');
@@ -15,4 +16,9 @@ test('cli rejects unsupported source', () => {
 
 test('cli rejects unsupported trade source', () => {
   assert.throws(() => parseCliArgs(['--trade-source', 'foo']), /Unsupported trade source/);
+});
+
+
+test('cli rejects unsupported mode', () => {
+  assert.throws(() => parseCliArgs(['--mode', 'live']), /Unsupported mode/);
 });

--- a/paper-trading-mvp/tests/cli.test.ts
+++ b/paper-trading-mvp/tests/cli.test.ts
@@ -3,11 +3,12 @@ import assert from 'node:assert/strict';
 import { parseCliArgs } from '../src/utils/cli';
 
 test('cli parses source polymarket and trade source csv', () => {
-  const parsed = parseCliArgs(['--mode','backtest','--source', 'polymarket', '--trade-source', 'csv', '--trade-file', './fills.csv']);
+  const parsed = parseCliArgs(['--mode','backtest','--source', 'polymarket', '--trade-source', 'csv', '--trade-file', './fills.csv', '--llm', 'on']);
   assert.equal(parsed.mode, 'backtest');
   assert.equal(parsed.source, 'polymarket');
   assert.equal(parsed.tradeSource, 'csv');
   assert.equal(parsed.tradeFile, './fills.csv');
+  assert.equal(parsed.llm, 'on');
 });
 
 test('cli rejects unsupported source', () => {
@@ -21,4 +22,9 @@ test('cli rejects unsupported trade source', () => {
 
 test('cli rejects unsupported mode', () => {
   assert.throws(() => parseCliArgs(['--mode', 'live']), /Unsupported mode/);
+});
+
+
+test('cli rejects unsupported llm flag', () => {
+  assert.throws(() => parseCliArgs(['--llm', 'maybe']), /Unsupported --llm value/);
 });

--- a/paper-trading-mvp/tests/cli.test.ts
+++ b/paper-trading-mvp/tests/cli.test.ts
@@ -2,11 +2,17 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { parseCliArgs } from '../src/utils/cli';
 
-test('cli parses source polymarket', () => {
-  const parsed = parseCliArgs(['--source', 'polymarket']);
+test('cli parses source polymarket and trade source csv', () => {
+  const parsed = parseCliArgs(['--source', 'polymarket', '--trade-source', 'csv', '--trade-file', './fills.csv']);
   assert.equal(parsed.source, 'polymarket');
+  assert.equal(parsed.tradeSource, 'csv');
+  assert.equal(parsed.tradeFile, './fills.csv');
 });
 
 test('cli rejects unsupported source', () => {
   assert.throws(() => parseCliArgs(['--source', 'foo']), /Unsupported source/);
+});
+
+test('cli rejects unsupported trade source', () => {
+  assert.throws(() => parseCliArgs(['--trade-source', 'foo']), /Unsupported trade source/);
 });

--- a/paper-trading-mvp/tests/cli.test.ts
+++ b/paper-trading-mvp/tests/cli.test.ts
@@ -3,12 +3,13 @@ import assert from 'node:assert/strict';
 import { parseCliArgs } from '../src/utils/cli';
 
 test('cli parses source polymarket and trade source csv', () => {
-  const parsed = parseCliArgs(['--mode','backtest','--source', 'polymarket', '--trade-source', 'csv', '--trade-file', './fills.csv', '--llm', 'on']);
+  const parsed = parseCliArgs(['--mode','backtest','--source', 'polymarket', '--trade-source', 'csv', '--trade-file', './fills.csv', '--llm', 'on', '--strict-data', 'off']);
   assert.equal(parsed.mode, 'backtest');
   assert.equal(parsed.source, 'polymarket');
   assert.equal(parsed.tradeSource, 'csv');
   assert.equal(parsed.tradeFile, './fills.csv');
   assert.equal(parsed.llm, 'on');
+  assert.equal(parsed.strictData, 'off');
 });
 
 test('cli rejects unsupported source', () => {
@@ -27,4 +28,9 @@ test('cli rejects unsupported mode', () => {
 
 test('cli rejects unsupported llm flag', () => {
   assert.throws(() => parseCliArgs(['--llm', 'maybe']), /Unsupported --llm value/);
+});
+
+
+test('cli rejects unsupported strict-data flag', () => {
+  assert.throws(() => parseCliArgs(['--strict-data', 'maybe']), /Unsupported --strict-data value/);
 });

--- a/paper-trading-mvp/tests/dataQuality.test.ts
+++ b/paper-trading-mvp/tests/dataQuality.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { analyzeDataQuality } from '../src/validation/dataQuality';
+
+const baseMarket = {
+  id: 'm1',
+  question: 'q',
+  category: 'politics' as const,
+  currentPrice: 0.5,
+  spread: 0.02,
+  liquidity: 1000,
+  volume24h: 100,
+  resolutionAt: '2026-12-31T00:00:00Z'
+};
+
+const baseTrade = {
+  wallet: 'w1',
+  marketId: 'm1',
+  category: 'politics' as const,
+  stake: 100,
+  payout: 120,
+  timestamp: '2026-01-01T00:00:00Z'
+};
+
+test('duplicate market IDs', () => {
+  const r = analyzeDataQuality([{ ...baseMarket }, { ...baseMarket }], [{ ...baseTrade }]);
+  assert.match(r.criticalIssues.join(','), /duplicate_market_ids/);
+});
+
+test('duplicate trades', () => {
+  const r = analyzeDataQuality([{ ...baseMarket }], [{ ...baseTrade }, { ...baseTrade }]);
+  assert.match(r.warnings.join(','), /duplicate_trades/);
+});
+
+test('missing timestamps', () => {
+  const r = analyzeDataQuality([{ ...baseMarket }], [{ ...baseTrade, timestamp: '' }]);
+  assert.match(r.criticalIssues.join(','), /missing_or_invalid_timestamps/);
+});
+
+test('future timestamps', () => {
+  const future = new Date(Date.now() + 86_400_000).toISOString();
+  const r = analyzeDataQuality([{ ...baseMarket }], [{ ...baseTrade, timestamp: future }]);
+  assert.match(r.warnings.join(','), /future_timestamps/);
+});
+
+test('negative/out-of-range prices', () => {
+  const r = analyzeDataQuality([{ ...baseMarket, currentPrice: -0.1 }], [{ ...baseTrade }]);
+  assert.match(r.criticalIssues.join(','), /negative_prices/);
+});
+
+test('missing liquidity', () => {
+  const r = analyzeDataQuality([{ ...baseMarket, liquidity: 0 }], [{ ...baseTrade }]);
+  assert.match(r.warnings.join(','), /missing_or_invalid_liquidity/);
+});
+
+test('extreme outlier trade sizes', () => {
+  const r = analyzeDataQuality([{ ...baseMarket }], [{ ...baseTrade, stake: 10 }, { ...baseTrade, wallet: 'w2', stake: 12 }, { ...baseTrade, wallet: 'w3', stake: 5000 }]);
+  assert.match(r.warnings.join(','), /extreme_trade_size_outliers/);
+});
+
+test('markets with no matching trades and trades with no matching market', () => {
+  const r = analyzeDataQuality([{ ...baseMarket, id: 'm2' }], [{ ...baseTrade, marketId: 'mX' }]);
+  assert.match(r.warnings.join(','), /markets_with_no_matching_trades/);
+  assert.match(r.warnings.join(','), /trades_with_no_matching_market/);
+});

--- a/paper-trading-mvp/tests/engine.test.ts
+++ b/paper-trading-mvp/tests/engine.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { runPaperEngine } from '../src/paper/engine';
+import { defaultConfig } from '../src/config/defaultConfig';
+import { ScoredMarket } from '../src/types/market';
+
+const scanned: ScoredMarket[] = [
+  {
+    id: 'fx_market_1',
+    question: 'Will event A happen?',
+    category: 'politics',
+    currentPrice: 0.4,
+    spread: 0.02,
+    liquidity: 60000,
+    volume24h: 20000,
+    resolutionAt: '2026-12-31T00:00:00Z',
+    estimatedProbability: 0.5,
+    estimatedEdge: 0.1,
+    scannerPass: true,
+    scannerReasons: []
+  }
+];
+
+test('paper engine runs and computes metrics', () => {
+  const out = runPaperEngine(
+    [{ marketId: 'fx_market_1', direction: 'yes', strategy: 'convergence', consensusCount: 3, confidence: 0.9, desiredExposure: 1, rationale: 'ok' }],
+    scanned,
+    defaultConfig
+  );
+
+  assert.equal(out.ledger.trades.length, 1);
+  assert.equal(typeof out.metrics.finalBankroll, 'number');
+});

--- a/paper-trading-mvp/tests/engine.test.ts
+++ b/paper-trading-mvp/tests/engine.test.ts
@@ -25,6 +25,7 @@ test('paper engine runs and computes metrics', () => {
   const out = runPaperEngine(
     [{ marketId: 'fx_market_1', direction: 'yes', strategy: 'convergence', consensusCount: 3, confidence: 0.9, desiredExposure: 1, rationale: 'ok' }],
     scanned,
+    [{ wallet: "w", totalTrades: 5, winRate: 0.6, realizedPnl: 10, roi: 0.1, averageTradeSize: 50, maxDrawdown: 5, categoryConcentration: 0.7, confidenceScore: 0.8, trustedSample: true, rankScore: 1 }],
     defaultConfig
   );
 

--- a/paper-trading-mvp/tests/exit.test.ts
+++ b/paper-trading-mvp/tests/exit.test.ts
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { simulateExit } from '../src/agents/exit';
+import { defaultConfig } from '../src/config/defaultConfig';
+
+test('exit simulation produces deterministic reason and pnl', () => {
+  const result = simulateExit(
+    {
+      id: 'sim_fx_market_1_1',
+      marketId: 'fx_market_1',
+      question: 'q',
+      direction: 'yes',
+      entryPrice: 0.4,
+      positionSize: 100,
+      quantity: 250,
+      openedAt: '2026-01-01T00:00:00Z',
+      maxHoldingMinutes: 60
+    },
+    defaultConfig
+  );
+
+  assert.equal(typeof result.pnl, 'number');
+  assert.ok(result.exitReason.length > 0);
+});

--- a/paper-trading-mvp/tests/fixtures/markets.fixture.json
+++ b/paper-trading-mvp/tests/fixtures/markets.fixture.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "fx_market_1",
+    "question": "Will event A happen?",
+    "category": "politics",
+    "currentPrice": 0.4,
+    "spread": 0.02,
+    "liquidity": 60000,
+    "volume24h": 20000,
+    "resolutionAt": "2026-12-31T00:00:00Z"
+  },
+  {
+    "id": "fx_market_2",
+    "question": "Will event B happen?",
+    "category": "other",
+    "currentPrice": 0.5,
+    "spread": 0.09,
+    "liquidity": 1000,
+    "volume24h": 100,
+    "resolutionAt": "2026-07-01T00:00:00Z"
+  }
+]

--- a/paper-trading-mvp/tests/fixtures/trades.fixture.json
+++ b/paper-trading-mvp/tests/fixtures/trades.fixture.json
@@ -1,0 +1,6 @@
+[
+  {"wallet":"0x1","marketId":"fx_market_1","category":"politics","stake":100,"payout":170,"timestamp":"2026-01-01T00:00:00Z"},
+  {"wallet":"0x1","marketId":"fx_market_1","category":"politics","stake":80,"payout":0,"timestamp":"2026-01-02T00:00:00Z"},
+  {"wallet":"0x2","marketId":"fx_market_1","category":"macro","stake":100,"payout":0,"timestamp":"2026-01-03T00:00:00Z"},
+  {"wallet":"0x2","marketId":"fx_market_1","category":"macro","stake":100,"payout":160,"timestamp":"2026-01-04T00:00:00Z"}
+]

--- a/paper-trading-mvp/tests/importer.test.ts
+++ b/paper-trading-mvp/tests/importer.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { importAndNormalize } from '../src/import/importer';
+
+test('importer normalizes market and trade json files', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'importer-'));
+
+  const rawMarkets = [
+    { id: 'm1', question: 'Q1', category: 'politics', bestBid: 0.45, bestAsk: 0.48, liquidity: 10000, volume: 50000, endDate: '2024-11-01T00:00:00Z' }
+  ];
+  const rawTrades = [
+    { maker: '0xabc', market_id: 'm1', category: 'politics', usd_amount: 50, price: 0.5, timestamp: '2024-10-01T00:00:00Z' }
+  ];
+
+  const marketsIn = path.join(tmp, 'markets.json');
+  const tradesIn = path.join(tmp, 'trades.json');
+  const marketsOut = path.join(tmp, 'real_markets.json');
+  const tradesOut = path.join(tmp, 'real_trades.json');
+
+  fs.writeFileSync(marketsIn, JSON.stringify(rawMarkets));
+  fs.writeFileSync(tradesIn, JSON.stringify(rawTrades));
+
+  const marketsResult = importAndNormalize(marketsIn, 'markets', marketsOut);
+  const tradesResult = importAndNormalize(tradesIn, 'trades', tradesOut);
+
+  assert.equal(marketsResult.count, 1);
+  assert.equal(tradesResult.count, 1);
+
+  const normalizedMarkets = JSON.parse(fs.readFileSync(marketsOut, 'utf-8')) as Array<Record<string, unknown>>;
+  const normalizedTrades = JSON.parse(fs.readFileSync(tradesOut, 'utf-8')) as Array<Record<string, unknown>>;
+
+  assert.equal(normalizedMarkets[0].id, 'm1');
+  assert.equal(normalizedTrades[0].marketId, 'm1');
+});

--- a/paper-trading-mvp/tests/llmResearch.test.ts
+++ b/paper-trading-mvp/tests/llmResearch.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { runLlmResearch } from '../src/agents/llmResearch';
+import { mergeConfig, defaultConfig } from '../src/config/defaultConfig';
+import { buildStrategyDecisions } from '../src/agents/strategy';
+import { runPaperEngine } from '../src/paper/engine';
+import { ScoredMarket } from '../src/types/market';
+
+const market: ScoredMarket = {
+  id: 'm1',
+  question: 'Q',
+  category: 'politics',
+  currentPrice: 0.4,
+  spread: 0.02,
+  liquidity: 50000,
+  volume24h: 10000,
+  resolutionAt: new Date(Date.now() + 48 * 3600_000).toISOString(),
+  estimatedProbability: 0.5,
+  estimatedEdge: 0.1,
+  scannerPass: true,
+  scannerReasons: []
+};
+
+test('llm valid response parses', async () => {
+  process.env.OPENAI_API_KEY = 'x';
+  const cfg = mergeConfig(defaultConfig, { llm: { ...defaultConfig.llm, enabled: true, provider: 'openai' } });
+  const fakeFetch = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: JSON.stringify([{ marketId: 'm1', estimatedProbability: 0.6, confidence: 0.7, reasoningSummary: 'ok', riskFlags: ['x'], pass: true }]) } }]
+    })
+  }) as Response;
+
+  const out = await runLlmResearch([market], cfg, fakeFetch as typeof fetch);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].marketId, 'm1');
+});
+
+test('llm malformed json falls back', async () => {
+  process.env.OPENAI_API_KEY = 'x';
+  const cfg = mergeConfig(defaultConfig, { llm: { ...defaultConfig.llm, enabled: true, provider: 'openai' } });
+  const fakeFetch = async () => ({ ok: true, status: 200, json: async () => ({ choices: [{ message: { content: 'not-json' } }] }) }) as Response;
+  const out = await runLlmResearch([market], cfg, fakeFetch as typeof fetch);
+  assert.equal(out.length, 0);
+});
+
+test('llm timeout/failure falls back', async () => {
+  process.env.OPENAI_API_KEY = 'x';
+  const cfg = mergeConfig(defaultConfig, { llm: { ...defaultConfig.llm, enabled: true, provider: 'openai', timeoutMs: 1 } });
+  const hangingFetch = async () => await new Promise<Response>(() => undefined);
+  const out = await runLlmResearch([market], cfg, hangingFetch as typeof fetch);
+  assert.equal(out.length, 0);
+});
+
+test('llm pass cannot bypass guardrails', () => {
+  const lowLiquidityMarket = { ...market, liquidity: 10 };
+  const wallets = [{ wallet: 'w', totalTrades: 5, winRate: 0.6, realizedPnl: 10, roi: 0.1, averageTradeSize: 50, maxDrawdown: 5, categoryConcentration: 0.8, confidenceScore: 0.9, trustedSample: true, rankScore: 1 }];
+  const research = [{ market_id: 'm1', question: 'Q', current_price: 0.4, estimated_probability: 0.6, edge: 0.2, confidence: 0.8, reasoning_summary: 'r', risk_flags: [], pass: true }];
+  const llm = [{ marketId: 'm1', estimatedProbability: 0.7, confidence: 0.9, reasoningSummary: 'llm', riskFlags: [], pass: true }];
+
+  const decisions = buildStrategyDecisions([lowLiquidityMarket], research, wallets, defaultConfig, llm);
+  const out = runPaperEngine(decisions, [lowLiquidityMarket], wallets, defaultConfig);
+  assert.equal(out.ledger.trades.length, 0);
+  assert.equal(out.rejections.length > 0, true);
+});

--- a/paper-trading-mvp/tests/polymarketMarketSource.test.ts
+++ b/paper-trading-mvp/tests/polymarketMarketSource.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { defaultConfig } from '../src/config/defaultConfig';
+import { loadPolymarketMarkets } from '../src/data/polymarketMarketSource';
+
+test('polymarket source normalizes active markets', async () => {
+  const fakeFetch = async () =>
+    ({
+      ok: true,
+      status: 200,
+      json: async () => [
+        {
+          id: '123',
+          question: 'Will X happen?',
+          active: true,
+          closed: false,
+          endDate: '2026-12-01T00:00:00Z',
+          liquidity: '10000',
+          volume: '2500',
+          bestBid: '0.44',
+          bestAsk: '0.48',
+          outcomePrices: '[0.46,0.54]',
+          category: 'politics'
+        }
+      ]
+    }) as Response;
+
+  const markets = await loadPolymarketMarkets(defaultConfig, fakeFetch as typeof fetch);
+  assert.equal(markets.length, 1);
+  assert.equal(markets[0].id, '123');
+  assert.equal(markets[0].currentPrice, 0.46);
+});
+
+test('polymarket source throws on network failure', async () => {
+  const fakeFetch = async () => {
+    throw new Error('down');
+  };
+  await assert.rejects(() => loadPolymarketMarkets(defaultConfig, fakeFetch as typeof fetch), /network/);
+});
+
+test('polymarket source throws on malformed payload and empty list', async () => {
+  const malformedFetch = async () => ({ ok: true, status: 200, json: async () => ({}) }) as Response;
+  await assert.rejects(() => loadPolymarketMarkets(defaultConfig, malformedFetch as typeof fetch), /expected an array/);
+
+  const emptyFetch = async () => ({ ok: true, status: 200, json: async () => [] }) as Response;
+  await assert.rejects(() => loadPolymarketMarkets(defaultConfig, emptyFetch as typeof fetch), /no active markets/);
+});

--- a/paper-trading-mvp/tests/reportBuilder.test.ts
+++ b/paper-trading-mvp/tests/reportBuilder.test.ts
@@ -14,6 +14,7 @@ test('report builder generates markdown and html', () => {
   fs.writeFileSync(path.join(artifacts, 'paper_ledger.json'), JSON.stringify({ bankroll: 10100, trades: [{ marketId: 'm1', pnl: 10, roi: 0.1 }] }));
   fs.writeFileSync(path.join(artifacts, 'guardrail_rejections.json'), JSON.stringify([{ marketId: 'm2', reasons: ['spread_above_maximum'] }]));
   fs.writeFileSync(path.join(artifacts, 'llm_research.json'), JSON.stringify([]));
+  fs.writeFileSync(path.join(artifacts, 'data_quality_report.json'), JSON.stringify({ criticalIssues: ['duplicate_market_ids:m1'], warnings: ['future_timestamps:1'] }));
   fs.writeFileSync(path.join(artifacts, 'backtest_train_summary.json'), JSON.stringify({ roi: 0.1, winRate: 0.5 }));
   fs.writeFileSync(path.join(artifacts, 'backtest_test_summary.json'), JSON.stringify({ roi: 0.02, winRate: 0.45 }));
 
@@ -26,6 +27,7 @@ test('report builder generates markdown and html', () => {
     const md = fs.readFileSync(out.mdPath, 'utf-8');
     assert.match(md, /Run mode:\*\* paper/);
     assert.match(md, /Rejected trades by guardrail reason/);
+    assert.match(md, /Data quality diagnostics/);
   } finally {
     process.chdir(cwd);
   }

--- a/paper-trading-mvp/tests/reportBuilder.test.ts
+++ b/paper-trading-mvp/tests/reportBuilder.test.ts
@@ -28,6 +28,7 @@ test('report builder generates markdown and html', () => {
     assert.match(md, /Run mode:\*\* paper/);
     assert.match(md, /Rejected trades by guardrail reason/);
     assert.match(md, /Data quality diagnostics/);
+    assert.match(md, /Reality Check/);
   } finally {
     process.chdir(cwd);
   }

--- a/paper-trading-mvp/tests/reportBuilder.test.ts
+++ b/paper-trading-mvp/tests/reportBuilder.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildReportArtifacts } from '../src/reporting/reportBuilder';
+
+test('report builder generates markdown and html', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'report-'));
+  const artifacts = path.join(tmpRoot, 'artifacts');
+  fs.mkdirSync(artifacts, { recursive: true });
+
+  fs.writeFileSync(path.join(artifacts, 'run_summary.json'), JSON.stringify({ source: 'sample', final_bankroll: 10100, win_rate: 0.6, drawdown: 20, sharpe_like: 1.2, llm_enabled: false }));
+  fs.writeFileSync(path.join(artifacts, 'paper_ledger.json'), JSON.stringify({ bankroll: 10100, trades: [{ marketId: 'm1', pnl: 10, roi: 0.1 }] }));
+  fs.writeFileSync(path.join(artifacts, 'guardrail_rejections.json'), JSON.stringify([{ marketId: 'm2', reasons: ['spread_above_maximum'] }]));
+  fs.writeFileSync(path.join(artifacts, 'llm_research.json'), JSON.stringify([]));
+  fs.writeFileSync(path.join(artifacts, 'backtest_train_summary.json'), JSON.stringify({ roi: 0.1, winRate: 0.5 }));
+  fs.writeFileSync(path.join(artifacts, 'backtest_test_summary.json'), JSON.stringify({ roi: 0.02, winRate: 0.45 }));
+
+  const cwd = process.cwd();
+  process.chdir(tmpRoot);
+  try {
+    const out = buildReportArtifacts({ mode: 'paper', artifactsDir: 'artifacts' });
+    assert.equal(fs.existsSync(out.mdPath), true);
+    assert.equal(fs.existsSync(out.htmlPath), true);
+    const md = fs.readFileSync(out.mdPath, 'utf-8');
+    assert.match(md, /Run mode:\*\* paper/);
+    assert.match(md, /Rejected trades by guardrail reason/);
+  } finally {
+    process.chdir(cwd);
+  }
+});

--- a/paper-trading-mvp/tests/reportBuilder.test.ts
+++ b/paper-trading-mvp/tests/reportBuilder.test.ts
@@ -17,6 +17,7 @@ test('report builder generates markdown and html', () => {
   fs.writeFileSync(path.join(artifacts, 'data_quality_report.json'), JSON.stringify({ criticalIssues: ['duplicate_market_ids:m1'], warnings: ['future_timestamps:1'] }));
   fs.writeFileSync(path.join(artifacts, 'backtest_train_summary.json'), JSON.stringify({ roi: 0.1, winRate: 0.5 }));
   fs.writeFileSync(path.join(artifacts, 'backtest_test_summary.json'), JSON.stringify({ roi: 0.02, winRate: 0.45 }));
+  fs.writeFileSync(path.join(artifacts, 'pipeline_diagnostics.json'), JSON.stringify({ funnel: { marketsLoaded: 10, scannerPassed: 4, researchPassed: 3, walletSignalsAvailable: 2, strategyCandidates: 2, riskApproved: 1, guardrailApproved: 1, executedTrades: 1 }, topBlockers: [{ stage: 'scanner', reason: 'too_close_to_resolution', count: 6 }], nearMissCandidates: [{ marketId: 'm3', failedStage: 'scanner', failedReason: 'too_close_to_resolution', edge: 0.02, edgeAfterSlippage: 0.01, liquidity: 1000, spread: 0.1, timeToResolutionHours: -5, walletSignal: 0.2 }] }));
 
   const cwd = process.cwd();
   process.chdir(tmpRoot);
@@ -29,6 +30,9 @@ test('report builder generates markdown and html', () => {
     assert.match(md, /Rejected trades by guardrail reason/);
     assert.match(md, /Data quality diagnostics/);
     assert.match(md, /Reality Check/);
+    assert.match(md, /Pipeline Diagnostics/);
+    assert.match(md, /Biggest blockers/);
+    assert.match(md, /Near-miss opportunities/);
   } finally {
     process.chdir(cwd);
   }

--- a/paper-trading-mvp/tests/risk.test.ts
+++ b/paper-trading-mvp/tests/risk.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sizeDecision } from '../src/agents/risk';
+import { defaultConfig } from '../src/config/defaultConfig';
+
+test('risk blocks when max daily loss is hit', () => {
+  const sized = sizeDecision(
+    { marketId: 'm1', direction: 'yes', strategy: 'convergence', consensusCount: 2, confidence: 0.8, desiredExposure: 1, rationale: 'x' },
+    10000,
+    0.1,
+    -999,
+    0,
+    defaultConfig
+  );
+
+  assert.equal(sized.allowed, false);
+  assert.equal(sized.rejectionReason, 'max_daily_loss_hit');
+});

--- a/paper-trading-mvp/tests/scanner.test.ts
+++ b/paper-trading-mvp/tests/scanner.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import markets from './fixtures/markets.fixture.json';
+import { Market } from '../src/types/market';
+import { runScanner } from '../src/agents/scanner';
+import { defaultConfig } from '../src/config/defaultConfig';
+
+test('scanner filters and produces survivors', () => {
+  const scanned = runScanner(markets as Market[], defaultConfig);
+  assert.equal(scanned.length, 2);
+  assert.equal(scanned.filter((m) => m.scannerPass).length, 1);
+  assert.equal(scanned.find((m) => m.id === 'fx_market_2')?.scannerPass, false);
+});

--- a/paper-trading-mvp/tests/strategy.test.ts
+++ b/paper-trading-mvp/tests/strategy.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildStrategyDecisions } from '../src/agents/strategy';
+import { defaultConfig } from '../src/config/defaultConfig';
+import { ScoredMarket } from '../src/types/market';
+
+const scanned: ScoredMarket[] = [
+  {
+    id: 'fx_market_1',
+    question: 'Will event A happen?',
+    category: 'politics',
+    currentPrice: 0.4,
+    spread: 0.02,
+    liquidity: 60000,
+    volume24h: 20000,
+    resolutionAt: '2026-12-31T00:00:00Z',
+    estimatedProbability: 0.5,
+    estimatedEdge: 0.1,
+    scannerPass: true,
+    scannerReasons: []
+  }
+];
+
+test('strategy uses consensus to produce full exposure', () => {
+  const decisions = buildStrategyDecisions(
+    scanned,
+    [
+      {
+        market_id: 'fx_market_1',
+        question: 'Will event A happen?',
+        current_price: 0.4,
+        estimated_probability: 0.52,
+        edge: 0.12,
+        confidence: 0.7,
+        reasoning_summary: 'test',
+        risk_flags: [],
+        pass: true
+      }
+    ],
+    [{ wallet: 'x', numberOfTrades: 10, winRate: 0.7, realizedProfit: 100, maxDrawdown: 10, categoryConsistency: 0.8, trustedSample: true, rankScore: 9 }],
+    defaultConfig
+  );
+
+  assert.equal(decisions[0].direction, 'yes');
+  assert.equal(decisions[0].desiredExposure, 1);
+});

--- a/paper-trading-mvp/tests/strategy.test.ts
+++ b/paper-trading-mvp/tests/strategy.test.ts
@@ -37,7 +37,7 @@ test('strategy uses consensus to produce full exposure', () => {
         pass: true
       }
     ],
-    [{ wallet: 'x', numberOfTrades: 10, winRate: 0.7, realizedProfit: 100, maxDrawdown: 10, categoryConsistency: 0.8, trustedSample: true, rankScore: 9 }],
+    [{ wallet: 'x', totalTrades: 10, winRate: 0.7, realizedPnl: 100, roi: 0.2, averageTradeSize: 50, maxDrawdown: 10, categoryConcentration: 0.8, confidenceScore: 0.9, trustedSample: true, rankScore: 9 }],
     defaultConfig
   );
 

--- a/paper-trading-mvp/tests/strategyGuards.test.ts
+++ b/paper-trading-mvp/tests/strategyGuards.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { defaultConfig, mergeConfig } from '../src/config/defaultConfig';
+import { evaluateStrategyGuards } from '../src/validation/strategyGuards';
+
+const baseMarket = {
+  id: 'g1',
+  question: 'q',
+  category: 'politics' as const,
+  currentPrice: 0.4,
+  spread: 0.02,
+  liquidity: 50000,
+  volume24h: 10000,
+  resolutionAt: new Date(Date.now() + 48 * 3600_000).toISOString(),
+  estimatedProbability: 0.5,
+  estimatedEdge: 0.1,
+  scannerPass: true,
+  scannerReasons: [] as string[]
+};
+
+const decision = {
+  marketId: 'g1',
+  direction: 'yes' as const,
+  strategy: 'convergence' as const,
+  consensusCount: 2,
+  confidence: 0.8,
+  desiredExposure: 1,
+  rationale: 'x'
+};
+
+const walletScores = [{ wallet: 'w', totalTrades: 5, winRate: 0.6, realizedPnl: 10, roi: 0.1, averageTradeSize: 50, maxDrawdown: 5, categoryConcentration: 0.7, confidenceScore: 0.8, trustedSample: true, rankScore: 1 }];
+
+test('spread rejection', () => {
+  const market = { ...baseMarket, spread: 0.5 };
+  const out = evaluateStrategyGuards(market, decision, 100, walletScores, defaultConfig);
+  assert.equal(out.allowed, false);
+  assert.ok(out.reasons.includes('spread_above_maximum'));
+});
+
+test('liquidity rejection', () => {
+  const market = { ...baseMarket, liquidity: 10 };
+  const out = evaluateStrategyGuards(market, decision, 100, walletScores, defaultConfig);
+  assert.ok(out.reasons.includes('liquidity_below_minimum'));
+});
+
+test('stale data rejection', () => {
+  const market = { ...baseMarket, lastPriceUpdatedAt: new Date(Date.now() - 10 * 3600_000).toISOString() };
+  const out = evaluateStrategyGuards(market, decision, 100, walletScores, defaultConfig);
+  assert.ok(out.reasons.includes('stale_price_data'));
+});
+
+test('slippage removing edge rejection', () => {
+  const cfg = mergeConfig(defaultConfig, { guardrails: { ...defaultConfig.guardrails, minEdgeAfterSpread: 0.0001 } });
+  const market = { ...baseMarket, liquidity: 100, estimatedEdge: 0.01, spread: 0.009 };
+  const out = evaluateStrategyGuards(market, decision, 500, walletScores, cfg);
+  assert.ok(out.reasons.includes('slippage_removes_edge'));
+});

--- a/paper-trading-mvp/tests/tradeHistorySource.test.ts
+++ b/paper-trading-mvp/tests/tradeHistorySource.test.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { defaultConfig } from '../src/config/defaultConfig';
+import { __private__, loadTradeHistory } from '../src/data/polymarketTradeHistorySource';
+
+test('csv parser ingests valid rows', () => {
+  const csv = [
+    'wallet,marketId,category,stake,payout,timestamp',
+    '0xabc,mkt1,politics,100,150,2026-01-01T00:00:00Z',
+    '0xabc,mkt2,crypto,200,0,2026-01-02T00:00:00Z'
+  ].join('\n');
+
+  const parsed = __private__.parseCsvTrades(csv);
+  assert.equal(parsed.length, 2);
+  assert.equal(parsed[0].wallet, '0xabc');
+});
+
+test('csv parser rejects malformed row', () => {
+  const csv = [
+    'wallet,marketId,category,stake,payout,timestamp',
+    '0xabc,mkt1,politics,100,150'
+  ].join('\n');
+
+  assert.throws(() => __private__.parseCsvTrades(csv), /Malformed CSV row/);
+});
+
+test('json parser loads from local file', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'trade-json-'));
+  const file = path.join(tmp, 'trades.json');
+  fs.writeFileSync(
+    file,
+    JSON.stringify([
+      { wallet: '0x1', marketId: 'm1', category: 'politics', stake: 50, payout: 80, timestamp: '2026-01-01T00:00:00Z' }
+    ])
+  );
+
+  const trades = loadTradeHistory('json', file, defaultConfig);
+  assert.equal(trades.length, 1);
+});
+
+test('csv parser loads from local file', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'trade-csv-'));
+  const file = path.join(tmp, 'trades.csv');
+  fs.writeFileSync(file, 'wallet,marketId,category,stake,payout,timestamp\n0x1,m1,politics,50,80,2026-01-01T00:00:00Z\n');
+
+  const trades = loadTradeHistory('csv', file, defaultConfig);
+  assert.equal(trades.length, 1);
+});

--- a/paper-trading-mvp/tests/validation.test.ts
+++ b/paper-trading-mvp/tests/validation.test.ts
@@ -1,0 +1,7 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateMarkets } from '../src/utils/validation';
+
+test('validation fails clearly on malformed market json', () => {
+  assert.throws(() => validateMarkets([{ id: 'bad' }]), /Invalid string for field 'markets\[0\]\.resolutionAt'/);
+});

--- a/paper-trading-mvp/tests/walletIntel.test.ts
+++ b/paper-trading-mvp/tests/walletIntel.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import trades from './fixtures/trades.fixture.json';
+import { WalletTrade } from '../src/types/wallet';
+import { rankWallets } from '../src/agents/walletIntel';
+import { defaultConfig } from '../src/config/defaultConfig';
+
+test('wallet intel ranks wallets and applies trust sample penalty', () => {
+  const ranked = rankWallets(trades as WalletTrade[], defaultConfig);
+  assert.equal(ranked.length > 0, true);
+  assert.equal(ranked[0].wallet, '0x1');
+  assert.equal(ranked[0].trustedSample, false);
+});

--- a/paper-trading-mvp/tests/walletIntel.test.ts
+++ b/paper-trading-mvp/tests/walletIntel.test.ts
@@ -3,11 +3,23 @@ import assert from 'node:assert/strict';
 import trades from './fixtures/trades.fixture.json';
 import { WalletTrade } from '../src/types/wallet';
 import { rankWallets } from '../src/agents/walletIntel';
-import { defaultConfig } from '../src/config/defaultConfig';
+import { defaultConfig, mergeConfig } from '../src/config/defaultConfig';
 
-test('wallet intel ranks wallets and applies trust sample penalty', () => {
-  const ranked = rankWallets(trades as WalletTrade[], defaultConfig);
+test('wallet intel ranks wallets with expanded metrics and filters', () => {
+  const cfg = mergeConfig(defaultConfig, {
+    walletIntel: {
+      ...defaultConfig.walletIntel,
+      minTrades: 1,
+      minConfidenceScore: 0,
+      minRealizedPnl: -1000
+    }
+  });
+
+  const ranked = rankWallets(trades as WalletTrade[], cfg);
   assert.equal(ranked.length > 0, true);
   assert.equal(ranked[0].wallet, '0x1');
-  assert.equal(ranked[0].trustedSample, false);
+  assert.equal(typeof ranked[0].roi, 'number');
+  assert.equal(typeof ranked[0].averageTradeSize, 'number');
+  assert.equal(typeof ranked[0].categoryConcentration, 'number');
+  assert.equal(typeof ranked[0].confidenceScore, 'number');
 });

--- a/paper-trading-mvp/tsconfig.json
+++ b/paper-trading-mvp/tsconfig.json
@@ -8,8 +8,8 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": ".",
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }

--- a/paper-trading-mvp/tsconfig.json
+++ b/paper-trading-mvp/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, auditable CLI-first paper-trading MVP that implements the requested multi-agent prediction-market research pipeline without any live trading or private-key handling. 
- Focus on scanner, research scoring, wallet analytics, strategy consensus, capped-Kelly sizing, deterministic exit simulation, and a simple paper trading engine to evaluate research strategies. 
- Persist all artifacts as JSON for traceability and to make the project runnable offline with deterministic mock data. 

### Description
- Add a new `paper-trading-mvp/` TypeScript project with package scripts (`package.json`) and TypeScript config (`tsconfig.json`) and a CLI entrypoint at `src/index.ts` that runs the end-to-end pipeline. 
- Implement typed core models and config in `src/types/*` and `src/config/defaultConfig.ts`, and provide deterministic sample datasets in `data/sample_markets.json` and `data/sample_trades.json`. 
- Implement agents: `src/agents/scanner.ts`, `src/agents/research.ts`, `src/agents/walletIntel.ts`, `src/agents/strategy.ts`, `src/agents/risk.ts`, and `src/agents/exit.ts` with deterministic placeholder logic and JSON artifact outputs. 
- Implement the paper trading engine and ledger in `src/paper/engine.ts` and `src/paper/ledger.ts` which size simulated positions, record closed trades, persist `data/paper_ledger.json`, and compute performance metrics; add docs (`ARCHITECTURE.md`, `TODO.md`, `USER_STORIES.md`) and a README with quickstart. 

### Testing
- Ran `npm install` in `paper-trading-mvp/` successfully. 
- Ran `npm run dev` in `paper-trading-mvp/` successfully, and the pipeline executed end-to-end producing scanner artifacts, `data/research_output.json`, `data/top_wallets.json`, `data/paper_ledger.json`, and `data/run_summary.json`. 
- The run produced scanner survivors, strategy candidates, simulated trades, and computed metrics (final bankroll, win rate, drawdown, sharpe-like) confirming the pipeline operates end-to-end with the deterministic mocks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf89c6fc0832cbdcf8fcf62591727)